### PR TITLE
keep the same with v7.5.0

### DIFF
--- a/storage/resume_uploader.go
+++ b/storage/resume_uploader.go
@@ -119,10 +119,17 @@ func (p *ResumeUploader) rput(ctx context.Context, ret interface{}, upToken stri
 		fileInfo                               os.FileInfo = nil
 	)
 
+	if accessKey, bucket, err = getAkBucketFromUploadToken(upToken); err != nil {
+		return
+	}
+
 	if extra.UpHost != "" {
 		upHost = extra.UpHost
-	} else if accessKey, bucket, upHost, err = p.resumeUploaderAPIs().getAkAndBucketAndUpHostFromUploadToken(upToken); err != nil {
-		return
+	} else {
+		upHost, err = p.resumeUploaderAPIs().upHost(accessKey, bucket)
+		if err != nil {
+			return
+		}
 	}
 
 	if extra.Recorder != nil && fileDetails != nil {
@@ -143,11 +150,18 @@ func (p *ResumeUploader) rputWithoutSize(ctx context.Context, ret interface{}, u
 	}
 	extra.init()
 
-	var upHost string
+	var upHost, accessKey, bucket string
+	if accessKey, bucket, err = getAkBucketFromUploadToken(upToken); err != nil {
+		return
+	}
+
 	if extra.UpHost != "" {
 		upHost = extra.UpHost
-	} else if upHost, err = p.resumeUploaderAPIs().getUpHostFromUploadToken(upToken); err != nil {
-		return
+	} else {
+		upHost, err = p.resumeUploaderAPIs().upHost(accessKey, bucket)
+		if err != nil {
+			return
+		}
 	}
 
 	return uploadByWorkers(

--- a/storage/resume_uploader_apis.go
+++ b/storage/resume_uploader_apis.go
@@ -154,24 +154,6 @@ func (p *resumeUploaderAPIs) upHost(ak, bucket string) (upHost string, err error
 	return getUpHost(p.Cfg, ak, bucket)
 }
 
-func (p *resumeUploaderAPIs) getUpHostFromUploadToken(upToken string) (upHost string, err error) {
-	_, upHost, err = p.getBucketAndUpHostFromUploadToken(upToken)
-	return
-}
-
-func (p *resumeUploaderAPIs) getBucketAndUpHostFromUploadToken(upToken string) (bucket, upHost string, err error) {
-	_, bucket, upHost, err = p.getAkAndBucketAndUpHostFromUploadToken(upToken)
-	return
-}
-
-func (p *resumeUploaderAPIs) getAkAndBucketAndUpHostFromUploadToken(upToken string) (ak, bucket, upHost string, err error) {
-	if ak, bucket, err = getAkBucketFromUploadToken(upToken); err != nil {
-		return
-	}
-	upHost, err = p.upHost(ak, bucket)
-	return
-}
-
 func makeHeadersForUpload(upToken string) http.Header {
 	return makeHeadersForUploadEx(upToken, conf.CONTENT_TYPE_OCTET)
 }


### PR DESCRIPTION
保持和 老版本v7.5.0  extra.UpHost 的行为一致 https://github.com/qiniu/api.v7/blob/v7.5.0/storage/resume_upload.go#L153 ：
当 extra.UpHost  有值时，直接使用这个 host，不查询 uc.qbox.me  ----- 当前行为是 先查询  uc.qbox.me， 查询失败，直接失败，查询成功才判断 是否使用 extra.UpHost 。私有部署是下查询 uc 会失败，导致额外的 extra.UpHost 无效，整个都失败了。
推荐做法是设置正确的 Region 参数，废弃 extra.UpHost ，不过此参数已经公开，有历史代码依赖这个  extra.UpHost 。
外加 校验 token 格式是合法的。
