### PR TITLE
fix get log list error

### DIFF
--- a/cdn/api.go
+++ b/cdn/api.go
@@ -256,7 +256,7 @@ func (m *CdnManager) GetCdnLogList(day string, domains []string) (
 		return
 	}
 
-	if listLogResult.Error != "" {
+	if listLogResult.Code != 200 {
 		err = fmt.Errorf("get log list error, %d %s", listLogResult.Code, listLogResult.Error)
 		return
 	}


### PR DESCRIPTION
当listLogResult.Code为200，现在返回的listLogResult.Error是成功，不能通过Error字段来判断了