### PR TITLE
feat(ssl): Add API interfaces for managing SSL certificates

### DIFF
--- a/cdn/api.go
+++ b/cdn/api.go
@@ -305,3 +305,224 @@ func postRequest(mac *auth.Credentials, path string, body interface{}) (resData 
 
 	return
 }
+
+// CertListReq 获取ssl证书列表请求内容
+type CertListReq struct {
+	Marker string `json:"marker"`
+	Limit  int    `json:"limit"`
+}
+
+// CertListResp 获取ssl证书列表响应内容
+type CertListResp struct {
+	Marker string `json:"marker"`
+	Certs  []struct {
+		CertID     string   `json:"certid"`
+		Name       string   `json:"name"`
+		CommonName string   `json:"common_name"`
+		DNSNames   []string `json:"dnsnames"`
+		NotBefore  int      `json:"not_before"`
+		NotAfter   int      `json:"not_after"`
+		CreateTime int      `json:"create_time"`
+	} `json:"certs"`
+}
+
+// GetCertList 获取ssl证书列表
+func (m *CdnManager) GetCertList(marker string, limit int) (certList CertListResp, err error) {
+	reqParams := fmt.Sprintf("marker=%s&limit=%d", marker, limit)
+	urlStr := fmt.Sprintf("%s/sslcert?%s", FusionHost, reqParams)
+	req, reqErr := http.NewRequest("GET", urlStr, nil)
+	if reqErr != nil {
+		err = reqErr
+		return
+	}
+	accessToken, signErr := m.mac.SignRequest(req)
+	if signErr != nil {
+		err = signErr
+		return
+	}
+	req.Header.Add("Authorization", "QBox "+accessToken)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, respErr := http.DefaultClient.Do(req)
+	if respErr != nil {
+		err = respErr
+		return
+	}
+	defer resp.Body.Close()
+	resData, ioErr := ioutil.ReadAll(resp.Body)
+	if ioErr != nil {
+		err = ioErr
+		return
+	}
+	umErr := json.Unmarshal(resData, &certList)
+	if umErr != nil {
+		err = umErr
+		return
+	}
+
+	return
+}
+
+// CertDetailResp 获取单个ssl证书响应内容
+type CertDetailResp struct {
+	Name       string   `json:"name"`
+	CommonName string   `json:"common_name"`
+	DNSNames   []string `json:"dnsnames"`
+	NotBefore  int      `json:"not_before"`
+	NotAfter   int      `json:"not_after"`
+	Pri        string   `json:"pri"`
+	Ca         string   `json:"ca"`
+	CreateTime int      `json:"create_time"`
+}
+
+// RealCertDetailResp 当前的api返回与官方文档有差异
+type RealCertDetailResp struct {
+	CertID           string   `json:"certid"`
+	Name             string   `json:"name"`
+	UID              int      `json:"uid"`
+	CommonName       string   `json:"common_name"`
+	DNSNames         []string `json:"dnsnames"`
+	CreateTime       int      `json:"create_time"`
+	NotBefore        int      `json:"not_before"`
+	NotAfter         int      `json:"not_after"`
+	OrderID          string   `json:"orderid"`
+	ProductShortName string   `json:"product_short_name"`
+	ProductType      string   `json:"product_type"`
+	CertType         string   `json:"cert_type"`
+	Encrypt          string   `json:"encrypt"`
+	EncryptParameter string   `json:"encryptParameter"`
+	Enable           bool     `json:"enable"`
+	ChildOrderID     string   `json:"child_order_id"`
+	State            string   `json:"state"`
+	AutoRenew        bool     `json:"auto_renew"`
+	Renewable        bool     `json:"renewable"`
+	CA               string   `json:"ca"`
+}
+
+// GetCertDetail 获取单个ssl证书的详细信息
+func (m *CdnManager) GetCertDetail(certID string) (certDetail CertDetailResp, err error) {
+	urlStr := fmt.Sprintf("%s/sslcert/%s", FusionHost, certID)
+	req, reqErr := http.NewRequest("GET", urlStr, nil)
+	if reqErr != nil {
+		err = reqErr
+		return
+	}
+	accessToken, signErr := m.mac.SignRequest(req)
+	if signErr != nil {
+		err = signErr
+		return
+	}
+	req.Header.Add("Authorization", "QBox "+accessToken)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, respErr := http.DefaultClient.Do(req)
+	if respErr != nil {
+		err = respErr
+		return
+	}
+	defer resp.Body.Close()
+	resData, ioErr := ioutil.ReadAll(resp.Body)
+	if ioErr != nil {
+		err = ioErr
+		return
+	}
+	var resJson = struct {
+		Code  int
+		Error string
+		Cert  RealCertDetailResp
+	}{}
+	umErr := json.Unmarshal(resData, &resJson)
+	certDetail.Ca = resJson.Cert.CA
+	certDetail.CommonName = resJson.Cert.Name
+	certDetail.DNSNames = resJson.Cert.DNSNames
+	certDetail.Name = resJson.Cert.Name
+	certDetail.NotAfter = resJson.Cert.NotAfter
+	certDetail.NotBefore = resJson.Cert.NotBefore
+	certDetail.CreateTime = resJson.Cert.CreateTime
+	if umErr != nil {
+		err = umErr
+		return
+	}
+
+	return
+}
+
+// UploadCertReq 上传ssl证书请求内容
+type UploadCertReq struct {
+	Name       string `json:"name"`
+	CommonName string `json:"common_name"`
+	Pri        string `json:"pri"`
+	Ca         string `json:"ca"`
+}
+
+// UploadCertResp 上传ssl证书响应内容
+type UploadCertResp struct {
+	CertID string `json:"certID"`
+}
+
+// UploadCert 上传ssl证书
+func (m *CdnManager) UploadCert(name, commonName, pri, ca string) (resp UploadCertResp, err error) {
+	reqBody := UploadCertReq{
+		Name:       name,
+		CommonName: commonName,
+		Pri:        pri,
+		Ca:         ca,
+	}
+	urlStr := fmt.Sprintf("%s/sslcert", FusionHost)
+	reqData, _ := json.Marshal(reqBody)
+	req, reqErr := http.NewRequest("POST", urlStr, bytes.NewReader(reqData))
+	if reqErr != nil {
+		err = reqErr
+		return
+	}
+	accessToken, signErr := m.mac.SignRequest(req)
+	if signErr != nil {
+		err = signErr
+		return
+	}
+	req.Header.Add("Authorization", "QBox "+accessToken)
+	req.Header.Add("Content-Type", "application/json")
+	httpResp, respErr := http.DefaultClient.Do(req)
+	if respErr != nil {
+		err = respErr
+		return
+	}
+	defer httpResp.Body.Close()
+	resData, ioErr := ioutil.ReadAll(httpResp.Body)
+	if ioErr != nil {
+		err = ioErr
+		return
+	}
+	umErr := json.Unmarshal(resData, &resp)
+	if umErr != nil {
+		err = umErr
+		return
+	}
+	return
+}
+
+// DeleteCert 删除ssl证书
+func (m *CdnManager) DeleteCert(certID string) (err error) {
+	urlStr := fmt.Sprintf("%s/sslcert/%s", FusionHost, certID)
+	req, reqErr := http.NewRequest("DELETE", urlStr, nil)
+	if reqErr != nil {
+		err = reqErr
+		return
+	}
+	accessToken, signErr := m.mac.SignRequest(req)
+	if signErr != nil {
+		err = signErr
+		return
+	}
+	req.Header.Add("Authorization", "QBox "+accessToken)
+	req.Header.Add("Content-Type", "application/json")
+	resp, respErr := http.DefaultClient.Do(req)
+	if respErr != nil {
+		err = respErr
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return
+	}
+	return
+}


### PR DESCRIPTION
- Add CertListReq and CertListResp for retrieving SSL certificate lists
- Add CertDetailResp and RealCertDetailResp for retrieving SSL certificate details
- Implement GetCertList and GetCertDetail methods for fetching SSL certificate lists and details
- Add UploadCertReq and UploadCertResp for uploading SSL certificates
- Implement UploadCert method for uploading SSL certificates
- Implement DeleteCert method for deleting SSL certificates

Refs #136