### PR TITLE
fix: avoid send on closed channel race condition in BucketManager.Get

### DIFF
--- a/storage/bucket_get.go
+++ b/storage/bucket_get.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/qiniu/go-sdk/v7/storagev2/downloader"
@@ -139,10 +138,8 @@ func (m *BucketManager) Get(bucket, key string, options *GetObjectInput) (*GetOb
 		getObjectOutput GetObjectOutput
 		headerChan      = make(chan struct{})
 		errChan         = make(chan error)
-		areChansClosed  int32
 	)
 	defer func() {
-		atomic.StoreInt32(&areChansClosed, 1)
 		close(headerChan)
 		close(errChan)
 	}()
@@ -152,8 +149,10 @@ func (m *BucketManager) Get(bucket, key string, options *GetObjectInput) (*GetOb
 			Header: reqHeaders,
 			OnResponseHeader: func(h http.Header) {
 				defer func() {
-					if atomic.LoadInt32(&areChansClosed) == 0 {
-						headerChan <- struct{}{}
+					select {
+					case headerChan <- struct{}{}:
+					default:
+						// channel already closed, ignore
 					}
 				}()
 				getObjectOutput.ContentType = h.Get("Content-Type")


### PR DESCRIPTION
## Summary

Fixes panic: send on closed channel error in BucketManager.Get method.

### Problem

When context is cancelled or main function returns before goroutine finishes, the deferred close(errChan) executes while goroutine is still trying to send, causing panic.

### Solution

Use select + default instead of atomic check:

```go
// Before (race condition):
if atomic.LoadInt32(&areChansClosed) == 0 {
    errChan <- err
}

// After (fixed):
select {
case errChan <- err:
default:
    // channel already closed, ignore
}
```