### PR TITLE
chore(makefile): add api-specs sync target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ integrationtest:
 staticcheck:
 	staticcheck `go list ./... | egrep -v 'examples|sms'`
 
+sync-api-specs:
+	git submodule update --init --recursive api-specs
+	git submodule update --remote api-specs
+
 generate:
 	go generate ./storagev2/
 	go generate ./iam/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test unittest integrationtest staticcheck sync-api-specs generate generate-sandbox sandbox-examples
+
 test:
 	go test -tags='unit integration' -failfast -count=1 -v -timeout 350m -coverprofile=coverage.txt `go list ./... | egrep -v 'examples|sms'` | tee -a test.log
 
@@ -10,9 +12,10 @@ integrationtest:
 staticcheck:
 	staticcheck `go list ./... | egrep -v 'examples|sms'`
 
+# 从远端更新 api-specs submodule 到最新提交。
+# 运行后请先检查 api-specs 的变更，再运行 make generate 或 make generate-sandbox 并提交。
 sync-api-specs:
-	git submodule update --init --recursive api-specs
-	git submodule update --remote api-specs
+	git submodule update --init --recursive --remote api-specs
 
 generate:
 	go generate ./storagev2/
@@ -26,13 +29,13 @@ generate-sandbox:
 	# 控制面 API
 	go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1 \
 		--config sandbox/internal/apis/oapi-codegen.yaml \
-		../api-specs/sandbox/openapi.yml
+		api-specs/sandbox/openapi.yml
 	# envd HTTP API
 	go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1 \
 		--config sandbox/internal/envdapi/oapi-codegen.yaml \
-		../api-specs/sandbox/envd/envd.yaml
+		api-specs/sandbox/envd/envd.yaml
 	# envd ConnectRPC（需要安装 buf、protoc-gen-go、protoc-gen-connect-go）
-	cd ../api-specs/sandbox/envd && buf generate
+	cd api-specs/sandbox/envd && buf generate
 	# 验证编译
 	go build ./sandbox/...
 


### PR DESCRIPTION
## Summary
- add a dedicated `make sync-api-specs` target
- initialize the `api-specs` submodule before updating it
- keep submodule synchronization explicit instead of coupling it to existing generate targets

## Validation
- run `make -n sync-api-specs`