### PR TITLE
feat(sandbox): add Qiniu AI API injection type

### DIFF
--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -85,6 +85,11 @@ const (
 	Openai OpenaiInjectionType = "openai"
 )
 
+// Defines values for QiniuInjectionType.
+const (
+	Qiniu QiniuInjectionType = "qiniu"
+)
+
 // Defines values for SandboxState.
 const (
 	Paused  SandboxState = "paused"
@@ -421,6 +426,24 @@ type OpenaiInjection struct {
 
 // OpenaiInjectionType Injection type identifier
 type OpenaiInjectionType string
+
+// QiniuInjection Qiniu AI API injection. Qiniu's gateway is compatible with both OpenAI and Anthropic
+// protocols on the same host, so the api_key is injected into whichever auth header the
+// outgoing request actually carries (Authorization or x-api-key).
+// Default host: api.qnaigc.com
+type QiniuInjection struct {
+	// APIKey API key for Qiniu AI API
+	APIKey *string `json:"api_key,omitempty"`
+
+	// BaseURL Optional base URL. If not specified, uses api.qnaigc.com
+	BaseURL *string `json:"base_url,omitempty"`
+
+	// Type Injection type identifier
+	Type QiniuInjectionType `json:"type"`
+}
+
+// QiniuInjectionType Injection type identifier
+type QiniuInjectionType string
 
 // ResumedSandbox defines model for ResumedSandbox.
 type ResumedSandbox struct {
@@ -1337,6 +1360,34 @@ func (t *Injection) MergeGeminiInjection(v GeminiInjection) error {
 	return err
 }
 
+// AsQiniuInjection returns the union data inside the Injection as a QiniuInjection
+func (t Injection) AsQiniuInjection() (QiniuInjection, error) {
+	var body QiniuInjection
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromQiniuInjection overwrites any union data inside the Injection as the provided QiniuInjection
+func (t *Injection) FromQiniuInjection(v QiniuInjection) error {
+	v.Type = "qiniu"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeQiniuInjection performs a merge with any union data inside the Injection, using the provided QiniuInjection
+func (t *Injection) MergeQiniuInjection(v QiniuInjection) error {
+	v.Type = "qiniu"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t Injection) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1359,6 +1410,8 @@ func (t Injection) ValueByDiscriminator() (interface{}, error) {
 		return t.AsHTTPInjection()
 	case "openai":
 		return t.AsOpenaiInjection()
+	case "qiniu":
+		return t.AsQiniuInjection()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}
@@ -1514,6 +1567,34 @@ func (t *SandboxInjection) MergeGeminiInjection(v GeminiInjection) error {
 	return err
 }
 
+// AsQiniuInjection returns the union data inside the SandboxInjection as a QiniuInjection
+func (t SandboxInjection) AsQiniuInjection() (QiniuInjection, error) {
+	var body QiniuInjection
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromQiniuInjection overwrites any union data inside the SandboxInjection as the provided QiniuInjection
+func (t *SandboxInjection) FromQiniuInjection(v QiniuInjection) error {
+	v.Type = "qiniu"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeQiniuInjection performs a merge with any union data inside the SandboxInjection, using the provided QiniuInjection
+func (t *SandboxInjection) MergeQiniuInjection(v QiniuInjection) error {
+	v.Type = "qiniu"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t SandboxInjection) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1538,6 +1619,8 @@ func (t SandboxInjection) ValueByDiscriminator() (interface{}, error) {
 		return t.AsInjectionByID()
 	case "openai":
 		return t.AsOpenaiInjection()
+	case "qiniu":
+		return t.AsQiniuInjection()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}

--- a/sandbox/types_injection_rule.go
+++ b/sandbox/types_injection_rule.go
@@ -41,6 +41,17 @@ type GeminiInjection struct {
 	BaseURL *string
 }
 
+// QiniuInjection 七牛 AI API 注入配置。七牛网关同时兼容 OpenAI 和 Anthropic 协议，
+// api_key 会注入到请求实际携带的认证头（Authorization 或 x-api-key）。
+// 默认 host: api.qnaigc.com
+type QiniuInjection struct {
+	// APIKey API 密钥。
+	APIKey *string
+
+	// BaseURL 可选 base URL，未指定时使用 api.qnaigc.com。
+	BaseURL *string
+}
+
 // HTTPInjection 自定义 HTTP 注入配置。
 type HTTPInjection struct {
 	// BaseURL 匹配 HTTPS 请求的 base URL。域名部分用于 host 匹配。
@@ -62,6 +73,9 @@ type InjectionSpec struct {
 	// Gemini Google Gemini API 注入。
 	Gemini *GeminiInjection
 
+	// Qiniu 七牛 AI API 注入。
+	Qiniu *QiniuInjection
+
 	// HTTP 自定义 HTTP 注入。
 	HTTP *HTTPInjection
 }
@@ -80,6 +94,9 @@ type SandboxInjectionSpec struct {
 
 	// Gemini Google Gemini API 注入。
 	Gemini *GeminiInjection
+
+	// Qiniu 七牛 AI API 注入。
+	Qiniu *QiniuInjection
 
 	// HTTP 自定义 HTTP 注入。
 	HTTP *HTTPInjection
@@ -164,8 +181,11 @@ func injectionSpecToAPI(spec InjectionSpec) (apis.Injection, error) {
 	if spec.HTTP != nil {
 		count++
 	}
+	if spec.Qiniu != nil {
+		count++
+	}
 	if count == 0 {
-		return apis.Injection{}, fmt.Errorf("InjectionSpec: exactly one injection type must be set (OpenAI, Anthropic, Gemini, or HTTP), got none")
+		return apis.Injection{}, fmt.Errorf("InjectionSpec: exactly one injection type must be set (OpenAI, Anthropic, Gemini, Qiniu, or HTTP), got none")
 	}
 	if count > 1 {
 		return apis.Injection{}, fmt.Errorf("InjectionSpec: exactly one injection type must be set, but got %d", count)
@@ -191,6 +211,12 @@ func injectionSpecToAPI(spec InjectionSpec) (apis.Injection, error) {
 			APIKey:  spec.Gemini.APIKey,
 			BaseURL: spec.Gemini.BaseURL,
 			Type:    apis.Gemini,
+		})
+	case spec.Qiniu != nil:
+		err = inj.FromQiniuInjection(apis.QiniuInjection{
+			APIKey:  spec.Qiniu.APIKey,
+			BaseURL: spec.Qiniu.BaseURL,
+			Type:    apis.Qiniu,
 		})
 	case spec.HTTP != nil:
 		err = inj.FromHTTPInjection(apis.HTTPInjection{
@@ -228,6 +254,12 @@ func sandboxInjectionSpecToAPI(spec SandboxInjectionSpec) (apis.SandboxInjection
 			APIKey:  spec.Gemini.APIKey,
 			BaseURL: spec.Gemini.BaseURL,
 			Type:    apis.Gemini,
+		})
+	case spec.Qiniu != nil:
+		err = si.FromQiniuInjection(apis.QiniuInjection{
+			APIKey:  spec.Qiniu.APIKey,
+			BaseURL: spec.Qiniu.BaseURL,
+			Type:    apis.Qiniu,
 		})
 	case spec.HTTP != nil:
 		err = si.FromHTTPInjection(apis.HTTPInjection{
@@ -267,6 +299,12 @@ func injectionSpecFromAPI(inj apis.Injection) (InjectionSpec, error) {
 			return InjectionSpec{}, err
 		}
 		return InjectionSpec{Gemini: &GeminiInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
+	case string(apis.Qiniu):
+		v, err := inj.AsQiniuInjection()
+		if err != nil {
+			return InjectionSpec{}, err
+		}
+		return InjectionSpec{Qiniu: &QiniuInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
 	case string(apis.HTTP):
 		v, err := inj.AsHTTPInjection()
 		if err != nil {


### PR DESCRIPTION
Add QiniuInjection to support Qiniu's AI gateway which is compatible with both OpenAI and Anthropic protocols on the same host.