### PR TITLE
chore: version to v7.26.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 7.26.9
+
+* 新增
+  * sandbox: 添加七牛 AI API 注入类型（QiniuInjection），支持七牛网关的 OpenAI/Anthropic 协议兼容注入
+
 ## 7.26.8
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.8
+require github.com/qiniu/go-sdk/v7 v7.26.9
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.8"
+const Version = "7.26.9"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## Summary

- sandbox: 添加七牛 AI API 注入类型（QiniuInjection），支持七牛网关的 OpenAI/Anthropic 协议兼容注入
- 版本号同步更新：`conf/conf.go`、`CHANGELOG.md`、`README.md`

## Version Checklist

- [x] `conf/conf.go` → `Version = "7.26.9"`
- [x] `CHANGELOG.md` → `## 7.26.9`
- [x] `README.md` → `require github.com/qiniu/go-sdk/v7 v7.26.9`
- [x] 单元测试通过
- [x] 静态检查通过