### PR TITLE
feat(sandbox): add RebuildTemplate

### DIFF
--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -1255,6 +1255,71 @@ func TestRebuildTemplateError(t *testing.T) {
 	}
 }
 
+func TestRebuildTemplateTransportError(t *testing.T) {
+	mock := &mockAPI{
+		rebuildTemplateFn: func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error) {
+			return nil, fmt.Errorf("network down")
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.RebuildTemplate(context.Background(), "tmpl-x", RebuildTemplateParams{Dockerfile: "FROM alpine\n"})
+	if err == nil || err.Error() != "network down" {
+		t.Fatalf("expected transport error 'network down', got %v", err)
+	}
+}
+
+func TestRebuildTemplateParamsToAPIForwardsAllFields(t *testing.T) {
+	alias := "my-alias"
+	cpu := int32(4)
+	mem := int32(2048)
+	start := "./start.sh"
+	ready := "./ready.sh"
+	team := "team-1"
+	p := RebuildTemplateParams{
+		Dockerfile: "FROM alpine\n",
+		Alias:      &alias,
+		CPUCount:   &cpu,
+		MemoryMB:   &mem,
+		StartCmd:   &start,
+		ReadyCmd:   &ready,
+		TeamID:     &team,
+	}
+	body := p.toAPI()
+	if body.Dockerfile != "FROM alpine\n" {
+		t.Errorf("Dockerfile not forwarded: %q", body.Dockerfile)
+	}
+	if body.Alias == nil || *body.Alias != alias {
+		t.Errorf("Alias not forwarded: %v", body.Alias)
+	}
+	if body.CPUCount == nil || *body.CPUCount != cpu {
+		t.Errorf("CPUCount not forwarded: %v", body.CPUCount)
+	}
+	if body.MemoryMB == nil || *body.MemoryMB != mem {
+		t.Errorf("MemoryMB not forwarded: %v", body.MemoryMB)
+	}
+	if body.StartCmd == nil || *body.StartCmd != start {
+		t.Errorf("StartCmd not forwarded: %v", body.StartCmd)
+	}
+	if body.ReadyCmd == nil || *body.ReadyCmd != ready {
+		t.Errorf("ReadyCmd not forwarded: %v", body.ReadyCmd)
+	}
+	if body.TeamID == nil || *body.TeamID != team {
+		t.Errorf("TeamID not forwarded: %v", body.TeamID)
+	}
+}
+
+func TestTemplateCreateResponseFromLegacyAPINil(t *testing.T) {
+	if got := templateCreateResponseFromLegacyAPI(nil); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestTemplateCreateResponseFromAPINil(t *testing.T) {
+	if got := templateCreateResponseFromAPI(nil); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
 // --- Template: GetTemplate ---
 
 func TestGetTemplate(t *testing.T) {

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -31,6 +31,7 @@ type mockAPI struct {
 	refreshSandboxFn         func(ctx context.Context, sandboxID apis.SandboxID, body apis.RefreshSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RefreshSandboxResponse, error)
 	listTemplatesFn          func(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error)
 	createTemplateV3Fn       func(ctx context.Context, body apis.CreateTemplateV3JSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateTemplateV3Response, error)
+	rebuildTemplateFn        func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error)
 	getTemplateFn            func(ctx context.Context, templateID apis.TemplateID, params *apis.GetTemplateParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateResponse, error)
 	deleteTemplateFn         func(ctx context.Context, templateID apis.TemplateID, editors ...apis.RequestEditorFn) (*apis.DeleteTemplateResponse, error)
 	getTemplateBuildStatusFn func(ctx context.Context, templateID apis.TemplateID, buildID apis.BuildID, params *apis.GetTemplateBuildStatusParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateBuildStatusResponse, error)
@@ -156,6 +157,9 @@ func (m *mockAPI) UpdateTemplateWithBodyWithResponse(ctx context.Context, templa
 }
 
 func (m *mockAPI) RebuildTemplateWithResponse(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error) {
+	if m.rebuildTemplateFn != nil {
+		return m.rebuildTemplateFn(ctx, templateID, body, editors...)
+	}
 	panic("not implemented")
 }
 
@@ -1185,6 +1189,67 @@ func TestCreateTemplateError(t *testing.T) {
 	}
 	c := newTestClient(mock)
 	_, err := c.CreateTemplate(context.Background(), CreateTemplateParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- Template: RebuildTemplate ---
+
+func TestRebuildTemplate(t *testing.T) {
+	var gotTemplateID apis.TemplateID
+	var gotBody apis.RebuildTemplateJSONRequestBody
+	mock := &mockAPI{
+		rebuildTemplateFn: func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error) {
+			gotTemplateID = templateID
+			gotBody = body
+			return &apis.RebuildTemplateResponse{
+				JSON202: &apis.TemplateLegacy{
+					TemplateID: string(templateID),
+					BuildID:    "build-2",
+					Aliases:    []string{"my-template"},
+				},
+				HTTPResponse: httpResponse(202),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	startCmd := "start.sh"
+	resp, err := c.RebuildTemplate(context.Background(), "tmpl-existing", RebuildTemplateParams{
+		Dockerfile: "FROM alpine\n",
+		StartCmd:   &startCmd,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTemplateID != "tmpl-existing" {
+		t.Errorf("expected templateID 'tmpl-existing', got %q", gotTemplateID)
+	}
+	if gotBody.Dockerfile != "FROM alpine\n" {
+		t.Errorf("expected dockerfile content forwarded, got %q", gotBody.Dockerfile)
+	}
+	if gotBody.StartCmd == nil || *gotBody.StartCmd != "start.sh" {
+		t.Errorf("expected startCmd forwarded, got %v", gotBody.StartCmd)
+	}
+	if resp.TemplateID != "tmpl-existing" {
+		t.Errorf("expected templateID 'tmpl-existing', got %q", resp.TemplateID)
+	}
+	if resp.BuildID != "build-2" {
+		t.Errorf("expected BuildID 'build-2', got %q", resp.BuildID)
+	}
+}
+
+func TestRebuildTemplateError(t *testing.T) {
+	mock := &mockAPI{
+		rebuildTemplateFn: func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error) {
+			return &apis.RebuildTemplateResponse{
+				HTTPResponse: httpResponse(400),
+				Body:         []byte(`{"message":"bad request"}`),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.RebuildTemplate(context.Background(), "tmpl-x", RebuildTemplateParams{Dockerfile: "FROM alpine\n"})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/sandbox/doc.go
+++ b/sandbox/doc.go
@@ -115,11 +115,15 @@
 //
 //   - [Client.ListTemplates] / [Client.GetTemplate]: 列出和查询模板
 //   - [Client.CreateTemplate]: 创建模板（返回 templateID 和 buildID）
+//   - [Client.RebuildTemplate]: 在已有模板上创建新的 waiting build（返回新 buildID）
 //   - [Client.UpdateTemplate] / [Client.DeleteTemplate]: 更新和删除模板
 //   - [Client.StartTemplateBuild] / [Client.WaitForBuild]: 启动构建并等待完成
 //   - [Client.GetTemplateBuildStatus] / [Client.GetTemplateBuildLogs]: 查询构建状态和日志
 //   - [Client.AssignTemplateTags] / [Client.DeleteTemplateTags]: 管理模板标签
 //   - [Client.GetTemplateByAlias]: 通过别名查找模板
+//
+// 已有模板的重新构建遵循 [Client.RebuildTemplate] → [Client.StartTemplateBuild] →
+// [Client.WaitForBuild] 三步流程：先申请一个新的 waiting build，再触发该 build，最后等待完成。
 //
 // # 网络访问
 //

--- a/sandbox/template.go
+++ b/sandbox/template.go
@@ -118,13 +118,7 @@ func (c *Client) RebuildTemplate(ctx context.Context, templateID string, body Re
 	if resp.JSON202 == nil {
 		return nil, newAPIError(resp.HTTPResponse, resp.Body)
 	}
-	legacy := resp.JSON202
-	return &TemplateCreateResponse{
-		TemplateID: legacy.TemplateID,
-		BuildID:    legacy.BuildID,
-		Aliases:    legacy.Aliases,
-		Public:     legacy.Public,
-	}, nil
+	return templateCreateResponseFromLegacyAPI(resp.JSON202), nil
 }
 
 // GetTemplateFiles 返回模板构建文件的上传链接。

--- a/sandbox/template.go
+++ b/sandbox/template.go
@@ -107,6 +107,26 @@ func (c *Client) StartTemplateBuild(ctx context.Context, templateID, buildID str
 	return nil
 }
 
+// RebuildTemplate 在已有模板上创建一个新的 waiting build（对应 POST /templates/{templateID}）。
+// 返回新 build 的标识（含 BuildID），调用方需随后调用 StartTemplateBuild 触发该 build。
+// 典型流程：RebuildTemplate → StartTemplateBuild → WaitForBuild。
+func (c *Client) RebuildTemplate(ctx context.Context, templateID string, body RebuildTemplateParams) (*TemplateCreateResponse, error) {
+	resp, err := c.api.RebuildTemplateWithResponse(ctx, templateID, body.toAPI())
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON202 == nil {
+		return nil, newAPIError(resp.HTTPResponse, resp.Body)
+	}
+	legacy := resp.JSON202
+	return &TemplateCreateResponse{
+		TemplateID: legacy.TemplateID,
+		BuildID:    legacy.BuildID,
+		Aliases:    legacy.Aliases,
+		Public:     legacy.Public,
+	}, nil
+}
+
 // GetTemplateFiles 返回模板构建文件的上传链接。
 func (c *Client) GetTemplateFiles(ctx context.Context, templateID, hash string) (*TemplateBuildFileUpload, error) {
 	resp, err := c.api.GetTemplateFilesWithResponse(ctx, templateID, hash)

--- a/sandbox/types_template.go
+++ b/sandbox/types_template.go
@@ -551,6 +551,18 @@ func templateCreateResponseFromAPI(a *apis.TemplateRequestResponseV3) *TemplateC
 	}
 }
 
+func templateCreateResponseFromLegacyAPI(a *apis.TemplateLegacy) *TemplateCreateResponse {
+	if a == nil {
+		return nil
+	}
+	return &TemplateCreateResponse{
+		TemplateID: a.TemplateID,
+		BuildID:    a.BuildID,
+		Aliases:    a.Aliases,
+		Public:     a.Public,
+	}
+}
+
 func templateBuildFileUploadFromAPI(a *apis.TemplateBuildFileUpload) *TemplateBuildFileUpload {
 	if a == nil {
 		return nil

--- a/sandbox/types_template.go
+++ b/sandbox/types_template.go
@@ -132,6 +132,44 @@ func (p *UpdateTemplateParams) toAPI() apis.UpdateTemplateJSONRequestBody {
 	}
 }
 
+// RebuildTemplateParams 重新构建已有模板的请求参数。
+// 对应 POST /templates/{templateID}：在已存在的模板上创建一个新的 waiting build，
+// 返回新的 buildID，后续可通过 StartTemplateBuild 驱动该 build。
+type RebuildTemplateParams struct {
+	// Dockerfile 必填，模板使用的 Dockerfile 内容。
+	Dockerfile string
+
+	// Alias 模板别名。
+	Alias *string
+
+	// CPUCount 沙箱 CPU 核数。
+	CPUCount *int32
+
+	// MemoryMB 沙箱内存大小（MiB）。
+	MemoryMB *int32
+
+	// StartCmd 构建完成后执行的启动命令。
+	StartCmd *string
+
+	// ReadyCmd 就绪检查命令。
+	ReadyCmd *string
+
+	// TeamID 团队 ID（已废弃）。
+	TeamID *string
+}
+
+func (p *RebuildTemplateParams) toAPI() apis.RebuildTemplateJSONRequestBody {
+	return apis.RebuildTemplateJSONRequestBody{
+		Alias:      p.Alias,
+		CPUCount:   p.CPUCount,
+		Dockerfile: p.Dockerfile,
+		MemoryMB:   p.MemoryMB,
+		ReadyCmd:   p.ReadyCmd,
+		StartCmd:   p.StartCmd,
+		TeamID:     p.TeamID,
+	}
+}
+
 // StartTemplateBuildParams 启动模板构建的请求参数。
 type StartTemplateBuildParams struct {
 	// Force 是否强制完整构建（忽略缓存）。


### PR DESCRIPTION
## Summary

已有模板的重新构建需要先通过 `POST /templates/{templateID}` 创建新的 waiting build，再由 `StartTemplateBuild` 驱动该 build —— 这是 E2B CLI 官方实现 (`packages/cli/src/commands/template/build.ts` 中的 `requestTemplateRebuild`) 遵循的流程。

之前 SDK 只暴露了底层 `oapi-codegen` 生成的 `RebuildTemplateWithResponse`，上层调用方（例如 qshell）在重建已有模板时只能复用旧 buildID，直接调用 `StartTemplateBuildV2` 会返回 `400 build is not in waiting state`。

## Changes

- `RebuildTemplateParams` 请求参数结构体（Dockerfile / Alias / CPU / Memory / Start / Ready / TeamID）
- `(*Client).RebuildTemplate(ctx, templateID, params) (*TemplateCreateResponse, error)` 高层封装
- 单元测试覆盖成功与错误路径