### PR TITLE
fix(sandbox): apiKeyEditor 同时注入 X-API-Key 与 Authorization: Bearer

### DIFF
--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -70,15 +70,26 @@ func reqidEditor() apis.RequestEditorFn {
 	}
 }
 
-// apiKeyEditor 返回一个 RequestEditorFn，用于注入 X-API-Key 请求头。
+// apiKeyEditor 返回一个 RequestEditorFn，用于注入 API Key 认证头。
+// 同时设置 X-API-Key 和 Authorization: Bearer，兼容不同端点对认证头的要求：
+//   - 多数端点接受 X-API-Key
+//   - 部分端点（如 POST /templates/{templateID} rebuild）要求 Authorization
+//
+// 与 E2B js-sdk (packages/js-sdk/src/api/index.ts) 的双 header 行为保持一致。
+//
+// 与 Credentials 共存：apiKeyEditor 作为 client-level editor 先于 per-request
+// editor 执行；GetCredentialsOption 返回的 editor 会 Set 覆盖 Authorization
+// 为 "Qiniu <sig>"，因此 Credentials 的优先级依旧生效，Bearer 只在未叠加
+// Credentials editor 时才会命中。
 func apiKeyEditor(apiKey string) apis.RequestEditorFn {
 	return func(ctx context.Context, req *http.Request) error {
 		if req.Header.Get("Authorization") != "" {
-			// 如果已经有 Authorization 头了，就不再添加 X-API-Key 头。
-			// 支持 Credentials 和 API Key 两种认证方式共存，优先使用 Credentials 认证。
+			// 调用方已在请求前手动预设 Authorization（非常规路径），尊重其选择，
+			// 同时不再追加 X-API-Key 以避免双认证头干扰。
 			return nil
 		}
 		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 		return nil
 	}
 }

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -80,12 +80,13 @@ func reqidEditor() apis.RequestEditorFn {
 // 与 Credentials 共存：apiKeyEditor 作为 client-level editor 先于 per-request
 // editor 执行；GetCredentialsOption 返回的 editor 会 Set 覆盖 Authorization
 // 为 "Qiniu <sig>"，因此 Credentials 的优先级依旧生效，Bearer 只在未叠加
-// Credentials editor 时才会命中。
+// Credentials editor 时才会命中。此时 X-API-Key 仍会保留在请求中，服务端
+// 接受并忽略，与改动前 APIKey-only 路径行为一致。
 func apiKeyEditor(apiKey string) apis.RequestEditorFn {
 	return func(ctx context.Context, req *http.Request) error {
 		if req.Header.Get("Authorization") != "" {
-			// 调用方已在请求前手动预设 Authorization（非常规路径），尊重其选择，
-			// 同时不再追加 X-API-Key 以避免双认证头干扰。
+			// 调用方已在进入 client-level editor 链之前手动预设 Authorization
+			// （非常规路径），尊重其选择并跳过注入，避免覆盖调用方的认证选择。
 			return nil
 		}
 		req.Header.Set("X-API-Key", apiKey)

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -313,6 +313,24 @@ func TestAPIKeyEditor(t *testing.T) {
 	if got := req.Header.Get("X-API-Key"); got != "test-key" {
 		t.Errorf("expected X-API-Key 'test-key', got %q", got)
 	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-key" {
+		t.Errorf("expected Authorization 'Bearer test-key', got %q", got)
+	}
+}
+
+func TestAPIKeyEditorSkipsWhenAuthorizationPresent(t *testing.T) {
+	editor := apiKeyEditor("test-key")
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	req.Header.Set("Authorization", "QBox ak:sign")
+	if err := editor(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "QBox ak:sign" {
+		t.Errorf("expected Authorization preserved, got %q", got)
+	}
+	if got := req.Header.Get("X-API-Key"); got != "" {
+		t.Errorf("expected X-API-Key not set when Authorization present, got %q", got)
+	}
 }
 
 func TestReqidEditor(t *testing.T) {

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -333,6 +333,38 @@ func TestAPIKeyEditorSkipsWhenAuthorizationPresent(t *testing.T) {
 	}
 }
 
+// TestAPIKeyEditorCredentialsTakesPrecedence 验证在真实调用顺序下
+// （client-level apiKeyEditor 先，per-request Credentials editor 后），
+// Credentials 的 Authorization 会覆盖 apiKeyEditor 写入的 Bearer，保持优先级。
+func TestAPIKeyEditorCredentialsTakesPrecedence(t *testing.T) {
+	apiKey := apiKeyEditor("test-key")
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+
+	// 1) client-level apiKeyEditor 先执行
+	if err := apiKey(context.Background(), req); err != nil {
+		t.Fatalf("apiKey editor error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer test-key" {
+		t.Fatalf("expected Bearer after apiKey editor, got %q", got)
+	}
+
+	// 2) per-request Credentials editor 后执行（模拟 GetCredentialsOption 返回的 editor）
+	credentials := func(ctx context.Context, r *http.Request) error {
+		r.Header.Set("Authorization", "Qiniu ak:sig")
+		return nil
+	}
+	if err := credentials(context.Background(), req); err != nil {
+		t.Fatalf("credentials editor error: %v", err)
+	}
+
+	if got := req.Header.Get("Authorization"); got != "Qiniu ak:sig" {
+		t.Errorf("expected Credentials to override Bearer, got %q", got)
+	}
+	if got := req.Header.Get("X-API-Key"); got != "test-key" {
+		t.Errorf("expected X-API-Key retained for backward compat, got %q", got)
+	}
+}
+
 func TestReqidEditor(t *testing.T) {
 	editor := reqidEditor()
 


### PR DESCRIPTION
## 背景

服务端部分端点（如 rebuild `POST /templates/{templateID}`）强制要求 `Authorization: Bearer <apiKey>`，仅 `X-API-Key` 会返回：

```
HTTP 401
{"code":401,"message":"authorization header is missing"}
```

其他端点（list / create / build status 等）两种 header 都接受。原 `apiKeyEditor` 只写 `X-API-Key`，导致 #210 合入后 `Client.RebuildTemplate` 调用实际仍然 401。

## 变更

`apiKeyEditor` 在未存在 Authorization 的前提下**同时写入** `X-API-Key` 和 `Authorization: Bearer <apiKey>`，与 E2B js-sdk 的行为对齐（见 `packages/js-sdk/src/api/index.ts` L79-86）。

## Credentials 共存保证

`applyEditors` 的执行顺序：client-level editors（含 `apiKeyEditor`）先，per-request editors 后。`GetCredentialsOption()` 返回的 editor 通过 `req.Header.Set(\"Authorization\", \"Qiniu <sig>\")` **无条件覆盖**先前的 Bearer，Credentials 的优先级保持不变。对于仅 Credentials 才有权限的端点（如 InjectionRule 系列），最终请求的 \`Authorization\` 仍然是 \`Qiniu <sig>\`。

保留原有 \"调用方预设 Authorization 时不追加 X-API-Key\" 的分支，尊重调用方手动覆盖的非常规场景。

## 测试

- 扩展 \`TestAPIKeyEditor\` 断言 \`X-API-Key\` 与 \`Bearer\` 同时存在
- 新增 \`TestAPIKeyEditorSkipsWhenAuthorizationPresent\` 覆盖预设 Authorization 的短路分支

已通过实际调用 \`POST /templates/{id}\` rebuild 端点验证修复生效（见 qshell 侧 rebuild 端到端测试）。

## 相关

跟进 #210（RebuildTemplate wrapper），解决其在生产网关下的 401 问题。