### PR TITLE
chore: version to v7.26.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 7.26.10
+
+* 新增
+  * sandbox: 添加 RebuildTemplate API，支持重建沙箱模板
+* 修复
+  * sandbox: apiKeyEditor 同时注入 X-API-Key 与 Authorization: Bearer，兼容更多上游鉴权方式
+
 ## 7.26.9
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.9
+require github.com/qiniu/go-sdk/v7 v7.26.10
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.9"
+const Version = "7.26.10"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## Summary

- 发布 v7.26.10 版本，同步更新 `conf/conf.go`、`CHANGELOG.md`、`README.md` 三处版本号
- 自 v7.26.9 起的变更：
  - 新增 sandbox `RebuildTemplate` API（#210）
  - 修复 sandbox `apiKeyEditor` 同时注入 `X-API-Key` 与 `Authorization: Bearer`（#211）

## Test plan

- [x] `make unittest` 通过
- [x] `make staticcheck` 通过