### PR TITLE
feat(sandbox): 添加 git 操作支持

### DIFF
--- a/examples/sandbox_git/main.go
+++ b/examples/sandbox_git/main.go
@@ -189,14 +189,20 @@ func main() {
 	if _, err := git.Add(ctx, repoPath, nil); err != nil {
 		log.Fatalf("Add 失败: %v", err)
 	}
-	st, _ = git.Status(ctx, repoPath, nil)
+	st, err = git.Status(ctx, repoPath, nil)
+	if err != nil {
+		log.Fatalf("Status 失败: %v", err)
+	}
 	fmt.Printf("Add 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
 	if _, err := git.Reset(ctx, repoPath, &sandbox.ResetOptions{
 		Paths: []string{"dirty.txt"},
 	}); err != nil {
 		log.Fatalf("Reset(paths) 失败: %v", err)
 	}
-	st, _ = git.Status(ctx, repoPath, nil)
+	st, err = git.Status(ctx, repoPath, nil)
+	if err != nil {
+		log.Fatalf("Status 失败: %v", err)
+	}
 	fmt.Printf("Reset(paths) 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
 
 	// 7b. Reset --hard：丢弃工作区改动并把 HEAD 重置到指定提交
@@ -229,7 +235,10 @@ func main() {
 	}); err != nil {
 		log.Fatalf("Restore(--staged) 失败: %v", err)
 	}
-	st, _ = git.Status(ctx, repoPath, nil)
+	st, err = git.Status(ctx, repoPath, nil)
+	if err != nil {
+		log.Fatalf("Status 失败: %v", err)
+	}
 	fmt.Printf("Restore --staged 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
 
 	// 7d. Restore --worktree --source=HEAD：把工作区改动恢复到 HEAD 版本
@@ -239,7 +248,10 @@ func main() {
 	}); err != nil {
 		log.Fatalf("Restore(--source HEAD) 失败: %v", err)
 	}
-	readme, _ = sb.Files().ReadText(ctx, repoPath+"/README.md")
+	readme, err = sb.Files().ReadText(ctx, repoPath+"/README.md")
+	if err != nil {
+		log.Fatalf("读取 README 失败: %v", err)
+	}
 	fmt.Printf("Restore --source HEAD 后 README.md = %q\n", readme)
 
 	// 8. Remote 管理（含 Overwrite）

--- a/examples/sandbox_git/main.go
+++ b/examples/sandbox_git/main.go
@@ -1,7 +1,9 @@
 // sandbox_git 演示如何使用 Sandbox 的 Git 高层接口完成常见 git 操作。
 //
-// 本示例完全在沙箱内部进行，不依赖外部仓库；如果设置了 QINIU_GIT_REPO_URL（HTTPS）、
-// QINIU_GIT_USERNAME、QINIU_GIT_PASSWORD 环境变量，会额外演示带凭证的 Clone。
+// 本示例完全在沙箱内部进行，不依赖外部仓库：通过在沙箱内本地建立一个
+// bare 仓库当作 "remote"，串起 Init / Add / Commit / Push / Pull 闭环。
+// 如果设置了 QINIU_GIT_REPO_URL（HTTPS）、QINIU_GIT_USERNAME、
+// QINIU_GIT_PASSWORD 环境变量，会额外演示带凭证的 Clone。
 package main
 
 import (
@@ -30,7 +32,7 @@ func main() {
 		log.Fatalf("创建客户端失败: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 	defer cancel()
 
 	// 1. 选取可用模板并创建沙箱
@@ -50,7 +52,7 @@ func main() {
 	}
 	fmt.Printf("使用模板: %s\n", templateID)
 
-	timeout := int32(180)
+	timeout := int32(240)
 	sb, _, err := c.CreateAndWait(ctx, sandbox.CreateParams{
 		TemplateID: templateID,
 		Timeout:    &timeout,
@@ -72,30 +74,56 @@ func main() {
 
 	git := sb.Git()
 	repoPath := "/tmp/demo-repo"
+	bareRepoPath := "/tmp/demo-remote.git"
+	consumerPath := "/tmp/demo-consumer"
 
-	// 2. 初始化仓库
+	// 2. 初始化工作仓库
 	fmt.Println("\n--- Init ---")
 	if _, err := git.Init(ctx, repoPath, &sandbox.InitOptions{InitialBranch: "main"}); err != nil {
 		log.Fatalf("Init 失败: %v", err)
 	}
 	fmt.Printf("已初始化仓库: %s（initial-branch=main）\n", repoPath)
 
+	// 同时初始化一个 bare 仓库当作 remote
+	if _, err := git.Init(ctx, bareRepoPath, &sandbox.InitOptions{Bare: true, InitialBranch: "main"}); err != nil {
+		log.Fatalf("Init(bare) 失败: %v", err)
+	}
+	fmt.Printf("已初始化 bare 仓库: %s\n", bareRepoPath)
+
 	// 3. 配置提交用户（local scope）
-	fmt.Println("\n--- ConfigureUser ---")
+	fmt.Println("\n--- ConfigureUser / SetConfig / GetConfig ---")
 	if _, err := git.ConfigureUser(ctx, "Sandbox Demo", "demo@example.com", &sandbox.ConfigOptions{
 		Scope: sandbox.GitConfigScopeLocal,
 		Path:  repoPath,
 	}); err != nil {
 		log.Fatalf("ConfigureUser 失败: %v", err)
 	}
-	name, err := git.GetConfig(ctx, "user.name", &sandbox.ConfigOptions{
+	// SetConfig 演示：单独设置一个非 user 的键
+	if _, err := git.SetConfig(ctx, "core.autocrlf", "input", &sandbox.ConfigOptions{
+		Scope: sandbox.GitConfigScopeLocal,
+		Path:  repoPath,
+	}); err != nil {
+		log.Fatalf("SetConfig 失败: %v", err)
+	}
+	for _, key := range []string{"user.name", "user.email", "core.autocrlf"} {
+		val, err := git.GetConfig(ctx, key, &sandbox.ConfigOptions{
+			Scope: sandbox.GitConfigScopeLocal,
+			Path:  repoPath,
+		})
+		if err != nil {
+			log.Fatalf("GetConfig(%s) 失败: %v", key, err)
+		}
+		fmt.Printf("  %s = %q\n", key, val)
+	}
+	// 不存在的键返回空字符串
+	missing, err := git.GetConfig(ctx, "user.notexist", &sandbox.ConfigOptions{
 		Scope: sandbox.GitConfigScopeLocal,
 		Path:  repoPath,
 	})
 	if err != nil {
-		log.Fatalf("GetConfig 失败: %v", err)
+		log.Fatalf("GetConfig(missing) 失败: %v", err)
 	}
-	fmt.Printf("user.name = %q\n", name)
+	fmt.Printf("  user.notexist = %q（未配置）\n", missing)
 
 	// 4. 写入文件并暂存提交
 	fmt.Println("\n--- Add / Commit ---")
@@ -153,6 +181,8 @@ func main() {
 
 	// 7. Reset / Restore 演示
 	fmt.Println("\n--- Reset / Restore ---")
+
+	// 7a. Reset paths-only：取消暂存（不带 mode）
 	if _, err := sb.Files().Write(ctx, repoPath+"/dirty.txt", []byte("dirty\n")); err != nil {
 		log.Fatalf("写入脏文件失败: %v", err)
 	}
@@ -161,28 +191,68 @@ func main() {
 	}
 	st, _ = git.Status(ctx, repoPath, nil)
 	fmt.Printf("Add 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
-
-	// Reset：取消暂存（仅 paths，无 mode）
 	if _, err := git.Reset(ctx, repoPath, &sandbox.ResetOptions{
 		Paths: []string{"dirty.txt"},
 	}); err != nil {
-		log.Fatalf("Reset 失败: %v", err)
+		log.Fatalf("Reset(paths) 失败: %v", err)
 	}
 	st, _ = git.Status(ctx, repoPath, nil)
-	fmt.Printf("Reset 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
+	fmt.Printf("Reset(paths) 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
 
-	// Restore：丢弃工作区改动（这里 dirty.txt 是新文件，restore 不会删除未跟踪文件，仅作 API 演示）
-	if _, err := git.Restore(ctx, repoPath, &sandbox.RestoreOptions{
-		Paths: []string{"README.md"},
-	}); err != nil {
-		log.Fatalf("Restore 失败: %v", err)
+	// 7b. Reset --hard：丢弃工作区改动并把 HEAD 重置到指定提交
+	if _, err := sb.Files().Write(ctx, repoPath+"/README.md", []byte("# demo (modified)\n")); err != nil {
+		log.Fatalf("修改 README 失败: %v", err)
 	}
-	fmt.Println("Restore: 已恢复 README.md 工作区版本")
+	if _, err := git.Reset(ctx, repoPath, &sandbox.ResetOptions{
+		Mode:   sandbox.GitResetModeHard,
+		Target: "HEAD",
+	}); err != nil {
+		log.Fatalf("Reset(--hard HEAD) 失败: %v", err)
+	}
+	readme, err := sb.Files().ReadText(ctx, repoPath+"/README.md")
+	if err != nil {
+		log.Fatalf("读取 README 失败: %v", err)
+	}
+	fmt.Printf("Reset --hard 后 README.md = %q\n", readme)
 
-	// 8. Remote 管理
+	// 7c. Restore --staged：取消暂存（保留工作区）
+	if _, err := sb.Files().Write(ctx, repoPath+"/README.md", []byte("# demo (staged change)\n")); err != nil {
+		log.Fatalf("修改 README 失败: %v", err)
+	}
+	if _, err := git.Add(ctx, repoPath, nil); err != nil {
+		log.Fatalf("Add 失败: %v", err)
+	}
+	stagedPtr := boolPtr(true)
+	if _, err := git.Restore(ctx, repoPath, &sandbox.RestoreOptions{
+		Paths:  []string{"README.md"},
+		Staged: stagedPtr, // 仅取消暂存，工作区保留
+	}); err != nil {
+		log.Fatalf("Restore(--staged) 失败: %v", err)
+	}
+	st, _ = git.Status(ctx, repoPath, nil)
+	fmt.Printf("Restore --staged 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
+
+	// 7d. Restore --worktree --source=HEAD：把工作区改动恢复到 HEAD 版本
+	if _, err := git.Restore(ctx, repoPath, &sandbox.RestoreOptions{
+		Paths:  []string{"README.md"},
+		Source: "HEAD",
+	}); err != nil {
+		log.Fatalf("Restore(--source HEAD) 失败: %v", err)
+	}
+	readme, _ = sb.Files().ReadText(ctx, repoPath+"/README.md")
+	fmt.Printf("Restore --source HEAD 后 README.md = %q\n", readme)
+
+	// 8. Remote 管理（含 Overwrite）
 	fmt.Println("\n--- Remote ---")
-	if _, err := git.RemoteAdd(ctx, repoPath, "origin", "https://example.com/demo.git", nil); err != nil {
+	// 先用一个占位 URL 添加 origin
+	if _, err := git.RemoteAdd(ctx, repoPath, "origin", "https://example.com/placeholder.git", nil); err != nil {
 		log.Fatalf("RemoteAdd 失败: %v", err)
+	}
+	// 再用 Overwrite=true 把它改成本地 bare 仓库（用于后面的 push/pull）
+	if _, err := git.RemoteAdd(ctx, repoPath, "origin", bareRepoPath, &sandbox.RemoteAddOptions{
+		Overwrite: true,
+	}); err != nil {
+		log.Fatalf("RemoteAdd(overwrite) 失败: %v", err)
 	}
 	url, err := git.RemoteGet(ctx, repoPath, "origin", nil)
 	if err != nil {
@@ -190,14 +260,76 @@ func main() {
 	}
 	fmt.Printf("origin URL = %s\n", url)
 
-	// 不存在的 remote 返回空字符串
-	missing, err := git.RemoteGet(ctx, repoPath, "nonexistent", nil)
+	missingRemote, err := git.RemoteGet(ctx, repoPath, "nonexistent", nil)
 	if err != nil {
 		log.Fatalf("RemoteGet(nonexistent) 失败: %v", err)
 	}
-	fmt.Printf("nonexistent URL = %q（未配置）\n", missing)
+	fmt.Printf("nonexistent URL = %q（未配置）\n", missingRemote)
 
-	// 9. 可选：带凭证的 Clone（仅在 QINIU_GIT_REPO_URL 等环境变量齐备时执行）
+	// 9. Push（不带凭证；SetUpstream 默认 true）
+	fmt.Println("\n--- Push ---")
+	if _, err := git.Push(ctx, repoPath, &sandbox.PushOptions{
+		Remote: "origin",
+		Branch: "main",
+	}); err != nil {
+		log.Fatalf("Push 失败: %v", err)
+	}
+	fmt.Printf("已推送到 %s（main）\n", bareRepoPath)
+
+	// 10. Pull：再 clone 出一个 consumer 仓库，从同一个 bare remote 拉取
+	fmt.Println("\n--- Pull（通过本地 clone 演示）---")
+	// 用 git clone 本地路径作为 remote 来初始化 consumer（无凭证场景）
+	if _, err := git.Clone(ctx, bareRepoPath, &sandbox.CloneOptions{
+		Path: consumerPath,
+	}); err != nil {
+		log.Fatalf("本地 Clone 失败: %v", err)
+	}
+	fmt.Printf("已 clone 到 %s\n", consumerPath)
+
+	// 在 repoPath 里再做一次提交并 push
+	if _, err := sb.Files().Write(ctx, repoPath+"/CHANGELOG.md", []byte("# v1\n")); err != nil {
+		log.Fatalf("写入 CHANGELOG 失败: %v", err)
+	}
+	if _, err := git.Add(ctx, repoPath, nil); err != nil {
+		log.Fatalf("Add 失败: %v", err)
+	}
+	if _, err := git.Commit(ctx, repoPath, "docs: add CHANGELOG", nil); err != nil {
+		log.Fatalf("Commit 失败: %v", err)
+	}
+	if _, err := git.Push(ctx, repoPath, &sandbox.PushOptions{
+		Remote: "origin",
+		Branch: "main",
+	}); err != nil {
+		log.Fatalf("Push(2) 失败: %v", err)
+	}
+
+	// 在 consumer 里 Pull 拉取最新提交
+	if _, err := git.Pull(ctx, consumerPath, &sandbox.PullOptions{
+		Remote: "origin",
+		Branch: "main",
+	}); err != nil {
+		log.Fatalf("Pull 失败: %v", err)
+	}
+	exists, err := sb.Files().Exists(ctx, consumerPath+"/CHANGELOG.md")
+	if err != nil {
+		log.Fatalf("Exists 失败: %v", err)
+	}
+	fmt.Printf("Pull 后 consumer/CHANGELOG.md 存在 = %v\n", exists)
+
+	// 11. DangerouslyAuthenticate：演示 API 调用形态（仅写到沙箱内的全局 credential store）
+	fmt.Println("\n--- DangerouslyAuthenticate（仅在沙箱内持久化，不影响外部环境）---")
+	if _, err := git.DangerouslyAuthenticate(ctx, &sandbox.AuthenticateOptions{
+		Username: "demo-user",
+		Password: "demo-token",
+		Host:     "example.com",
+		// Protocol 缺省即 "https"，这里显式写出仅作演示
+		Protocol: "https",
+	}); err != nil {
+		log.Fatalf("DangerouslyAuthenticate 失败: %v", err)
+	}
+	fmt.Println("已通过 git credential approve 写入 example.com 的凭证")
+
+	// 12. 可选：带凭证的 Clone（仅在 QINIU_GIT_REPO_URL 等环境变量齐备时执行）
 	repoURL := os.Getenv("QINIU_GIT_REPO_URL")
 	username := os.Getenv("QINIU_GIT_USERNAME")
 	password := os.Getenv("QINIU_GIT_PASSWORD")
@@ -218,6 +350,9 @@ func main() {
 		}
 		fmt.Printf("clone 完成，origin URL = %s（不含凭证）\n", clonedURL)
 	} else {
-		fmt.Println("\n--- Clone 演示已跳过（未设置 QINIU_GIT_REPO_URL / QINIU_GIT_USERNAME / QINIU_GIT_PASSWORD）---")
+		fmt.Println("\n--- 远程 Clone 演示已跳过（未设置 QINIU_GIT_REPO_URL / QINIU_GIT_USERNAME / QINIU_GIT_PASSWORD）---")
 	}
 }
+
+// boolPtr 返回 bool 值的指针。
+func boolPtr(v bool) *bool { return &v }

--- a/examples/sandbox_git/main.go
+++ b/examples/sandbox_git/main.go
@@ -1,0 +1,223 @@
+// sandbox_git 演示如何使用 Sandbox 的 Git 高层接口完成常见 git 操作。
+//
+// 本示例完全在沙箱内部进行，不依赖外部仓库；如果设置了 QINIU_GIT_REPO_URL（HTTPS）、
+// QINIU_GIT_USERNAME、QINIU_GIT_PASSWORD 环境变量，会额外演示带凭证的 Clone。
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+)
+
+func main() {
+	apiKey := os.Getenv("QINIU_API_KEY")
+	if apiKey == "" {
+		log.Fatal("请设置 QINIU_API_KEY 环境变量")
+	}
+
+	apiURL := os.Getenv("QINIU_SANDBOX_API_URL")
+
+	c, err := sandbox.NewClient(&sandbox.Config{
+		APIKey:   apiKey,
+		Endpoint: apiURL,
+	})
+	if err != nil {
+		log.Fatalf("创建客户端失败: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	// 1. 选取可用模板并创建沙箱
+	templates, err := c.ListTemplates(ctx, nil)
+	if err != nil {
+		log.Fatalf("列出模板失败: %v", err)
+	}
+	var templateID string
+	for _, tmpl := range templates {
+		if tmpl.BuildStatus == sandbox.BuildStatusReady || tmpl.BuildStatus == sandbox.BuildStatusUploaded {
+			templateID = tmpl.TemplateID
+			break
+		}
+	}
+	if templateID == "" {
+		log.Fatal("没有构建成功的模板")
+	}
+	fmt.Printf("使用模板: %s\n", templateID)
+
+	timeout := int32(180)
+	sb, _, err := c.CreateAndWait(ctx, sandbox.CreateParams{
+		TemplateID: templateID,
+		Timeout:    &timeout,
+	}, sandbox.WithPollInterval(2*time.Second))
+	if err != nil {
+		log.Fatalf("创建沙箱失败: %v", err)
+	}
+	fmt.Printf("沙箱已就绪: %s\n", sb.ID())
+
+	defer func() {
+		killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer killCancel()
+		if err := sb.Kill(killCtx); err != nil {
+			log.Printf("终止沙箱失败: %v", err)
+		} else {
+			fmt.Printf("沙箱 %s 已终止\n", sb.ID())
+		}
+	}()
+
+	git := sb.Git()
+	repoPath := "/tmp/demo-repo"
+
+	// 2. 初始化仓库
+	fmt.Println("\n--- Init ---")
+	if _, err := git.Init(ctx, repoPath, &sandbox.InitOptions{InitialBranch: "main"}); err != nil {
+		log.Fatalf("Init 失败: %v", err)
+	}
+	fmt.Printf("已初始化仓库: %s（initial-branch=main）\n", repoPath)
+
+	// 3. 配置提交用户（local scope）
+	fmt.Println("\n--- ConfigureUser ---")
+	if _, err := git.ConfigureUser(ctx, "Sandbox Demo", "demo@example.com", &sandbox.ConfigOptions{
+		Scope: sandbox.GitConfigScopeLocal,
+		Path:  repoPath,
+	}); err != nil {
+		log.Fatalf("ConfigureUser 失败: %v", err)
+	}
+	name, err := git.GetConfig(ctx, "user.name", &sandbox.ConfigOptions{
+		Scope: sandbox.GitConfigScopeLocal,
+		Path:  repoPath,
+	})
+	if err != nil {
+		log.Fatalf("GetConfig 失败: %v", err)
+	}
+	fmt.Printf("user.name = %q\n", name)
+
+	// 4. 写入文件并暂存提交
+	fmt.Println("\n--- Add / Commit ---")
+	if _, err := sb.Files().Write(ctx, repoPath+"/README.md", []byte("# demo\n")); err != nil {
+		log.Fatalf("写入文件失败: %v", err)
+	}
+	if _, err := git.Add(ctx, repoPath, nil); err != nil { // nil → 默认 -A
+		log.Fatalf("Add 失败: %v", err)
+	}
+	if _, err := git.Commit(ctx, repoPath, "feat: initial commit", &sandbox.CommitOptions{
+		AuthorName:  "Sandbox Demo",
+		AuthorEmail: "demo@example.com",
+	}); err != nil {
+		log.Fatalf("Commit 失败: %v", err)
+	}
+	fmt.Println("已创建初始提交")
+
+	// 5. 查看状态
+	fmt.Println("\n--- Status ---")
+	st, err := git.Status(ctx, repoPath, nil)
+	if err != nil {
+		log.Fatalf("Status 失败: %v", err)
+	}
+	fmt.Printf("CurrentBranch=%s, Detached=%v, Clean=%v, Total=%d, Staged=%d, Unstaged=%d\n",
+		st.CurrentBranch, st.Detached, st.IsClean(), st.TotalCount(), st.StagedCount(), st.UnstagedCount())
+
+	// 6. 分支管理：CreateBranch -> 修改 -> Commit -> Branches -> CheckoutBranch -> DeleteBranch
+	fmt.Println("\n--- Branches ---")
+	if _, err := git.CreateBranch(ctx, repoPath, "feature/x", nil); err != nil {
+		log.Fatalf("CreateBranch 失败: %v", err)
+	}
+	if _, err := sb.Files().Write(ctx, repoPath+"/feature.txt", []byte("hello feature\n")); err != nil {
+		log.Fatalf("写入特性文件失败: %v", err)
+	}
+	if _, err := git.Add(ctx, repoPath, &sandbox.AddOptions{Files: []string{"feature.txt"}}); err != nil {
+		log.Fatalf("Add(files) 失败: %v", err)
+	}
+	if _, err := git.Commit(ctx, repoPath, "feat: add feature.txt", nil); err != nil {
+		log.Fatalf("Commit 失败: %v", err)
+	}
+
+	branches, err := git.Branches(ctx, repoPath, nil)
+	if err != nil {
+		log.Fatalf("Branches 失败: %v", err)
+	}
+	fmt.Printf("分支: %v，当前: %s\n", branches.Branches, branches.CurrentBranch)
+
+	if _, err := git.CheckoutBranch(ctx, repoPath, "main", nil); err != nil {
+		log.Fatalf("CheckoutBranch 失败: %v", err)
+	}
+	if _, err := git.DeleteBranch(ctx, repoPath, "feature/x", &sandbox.DeleteBranchOptions{Force: true}); err != nil {
+		log.Fatalf("DeleteBranch 失败: %v", err)
+	}
+	fmt.Println("已切回 main 并强制删除 feature/x")
+
+	// 7. Reset / Restore 演示
+	fmt.Println("\n--- Reset / Restore ---")
+	if _, err := sb.Files().Write(ctx, repoPath+"/dirty.txt", []byte("dirty\n")); err != nil {
+		log.Fatalf("写入脏文件失败: %v", err)
+	}
+	if _, err := git.Add(ctx, repoPath, nil); err != nil {
+		log.Fatalf("Add 失败: %v", err)
+	}
+	st, _ = git.Status(ctx, repoPath, nil)
+	fmt.Printf("Add 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
+
+	// Reset：取消暂存（仅 paths，无 mode）
+	if _, err := git.Reset(ctx, repoPath, &sandbox.ResetOptions{
+		Paths: []string{"dirty.txt"},
+	}); err != nil {
+		log.Fatalf("Reset 失败: %v", err)
+	}
+	st, _ = git.Status(ctx, repoPath, nil)
+	fmt.Printf("Reset 后 staged=%d，unstaged=%d\n", st.StagedCount(), st.UnstagedCount())
+
+	// Restore：丢弃工作区改动（这里 dirty.txt 是新文件，restore 不会删除未跟踪文件，仅作 API 演示）
+	if _, err := git.Restore(ctx, repoPath, &sandbox.RestoreOptions{
+		Paths: []string{"README.md"},
+	}); err != nil {
+		log.Fatalf("Restore 失败: %v", err)
+	}
+	fmt.Println("Restore: 已恢复 README.md 工作区版本")
+
+	// 8. Remote 管理
+	fmt.Println("\n--- Remote ---")
+	if _, err := git.RemoteAdd(ctx, repoPath, "origin", "https://example.com/demo.git", nil); err != nil {
+		log.Fatalf("RemoteAdd 失败: %v", err)
+	}
+	url, err := git.RemoteGet(ctx, repoPath, "origin", nil)
+	if err != nil {
+		log.Fatalf("RemoteGet 失败: %v", err)
+	}
+	fmt.Printf("origin URL = %s\n", url)
+
+	// 不存在的 remote 返回空字符串
+	missing, err := git.RemoteGet(ctx, repoPath, "nonexistent", nil)
+	if err != nil {
+		log.Fatalf("RemoteGet(nonexistent) 失败: %v", err)
+	}
+	fmt.Printf("nonexistent URL = %q（未配置）\n", missing)
+
+	// 9. 可选：带凭证的 Clone（仅在 QINIU_GIT_REPO_URL 等环境变量齐备时执行）
+	repoURL := os.Getenv("QINIU_GIT_REPO_URL")
+	username := os.Getenv("QINIU_GIT_USERNAME")
+	password := os.Getenv("QINIU_GIT_PASSWORD")
+	if repoURL != "" && username != "" && password != "" {
+		fmt.Println("\n--- Clone（HTTPS + token，clone 后会自动剥离 origin URL 中的凭证）---")
+		clonePath := "/tmp/cloned-repo"
+		if _, err := git.Clone(ctx, repoURL, &sandbox.CloneOptions{
+			Path:     clonePath,
+			Depth:    1,
+			Username: username,
+			Password: password,
+		}); err != nil {
+			log.Fatalf("Clone 失败: %v", err)
+		}
+		clonedURL, err := git.RemoteGet(ctx, clonePath, "origin", nil)
+		if err != nil {
+			log.Fatalf("RemoteGet(cloned) 失败: %v", err)
+		}
+		fmt.Printf("clone 完成，origin URL = %s（不含凭证）\n", clonedURL)
+	} else {
+		fmt.Println("\n--- Clone 演示已跳过（未设置 QINIU_GIT_REPO_URL / QINIU_GIT_USERNAME / QINIU_GIT_PASSWORD）---")
+	}
+}

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -403,12 +403,17 @@ func resolveConfigScope(scope GitConfigScope, repoPath string) (string, string, 
 
 // hasUpstream 检查当前分支是否配置了 upstream。
 func (g *Git) hasUpstream(ctx context.Context, path string, opts *GitOptions) (bool, error) {
-	cmd := buildGitCommand(buildHasUpstreamArgs(), path) + " >/dev/null 2>&1 && echo yes || echo no"
-	result, err := g.runShell(ctx, "rev-parse", cmd, opts)
-	if err != nil {
-		return false, err
+	_, err := g.runGit(ctx, "rev-parse", buildHasUpstreamArgs(), path, opts)
+	if err == nil {
+		return true, nil
 	}
-	return strings.TrimSpace(result.Stdout) == "yes", nil
+	// 未配置 upstream 时 rev-parse 退出码为 128，stderr 含 "no upstream" 等说明；
+	// 其他失败（仓库路径错误、git 自身问题）应原样向上抛出。
+	var ce *gitCommandError
+	if errors.As(err, &ce) && ce.Result != nil && isMissingUpstream(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 // resolveRemoteName 在凭证注入流程中确定要使用的 remote 名，并一并返回其 URL。

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -11,12 +11,18 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"time"
 )
 
 // defaultGitEnv 是所有 git 命令默认注入的环境变量，用于禁止交互式提示。
 var defaultGitEnv = map[string]string{
 	"GIT_TERMINAL_PROMPT": "0",
 }
+
+// credentialCleanupTimeout 是凭证清理（strip / 恢复 origin URL）使用的兜底超时。
+// 这些步骤刻意脱离主 ctx，确保主 ctx 取消后也能执行；但需要一个有限时间，
+// 避免沙箱响应慢或网络异常时调用方协程被永久卡住。
+const credentialCleanupTimeout = 10 * time.Second
 
 // Git 提供沙箱内的 git 操作接口。
 //
@@ -57,7 +63,11 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 
 	if plan.shouldStrip {
 		// 即使 ctx 已取消也要清理凭证，避免带凭证的 URL 残留在 .git/config。
-		if _, serr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions); serr != nil {
+		// 用独立的带超时 ctx，防止沙箱异常时无限阻塞。
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), credentialCleanupTimeout)
+		_, serr := g.runGit(cleanupCtx, "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions)
+		cancel()
+		if serr != nil {
 			return result, fmt.Errorf("clone succeeded but failed to strip credentials: %w", serr)
 		}
 	}
@@ -608,8 +618,11 @@ func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalU
 	}
 	defer func() {
 		// 即使 ctx 已取消也要恢复原 URL，避免凭证遗留在 .git/config。
+		// 用独立的带超时 ctx，防止沙箱异常时 defer 永久阻塞。
 		// 恢复 URL 是安全相关步骤，主操作错误不应吞掉它；用 errors.Join 同时保留两者。
-		_, restoreErr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), credentialCleanupTimeout)
+		defer cancel()
+		_, restoreErr := g.runGit(cleanupCtx, "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
 		err = errors.Join(err, restoreErr)
 	}()
 	return fn()

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -202,8 +202,10 @@ func (g *Git) Restore(ctx context.Context, path string, opts *RestoreOptions) (*
 // 当未显式指定 Remote 时，SDK 会尝试自动选中仓库唯一的 remote（与"自动选择单一 remote"
 // 契约一致）；多 remote / 无 remote 时回退到 git 原生行为或返回带凭证场景下的明确错误。
 //
-// 当 SetUpstream=true 且未显式给 Branch 时，SDK 会通过 git rev-parse 取出当前分支名再
-// 拼到 push 命令上，避免 `git push --set-upstream <remote>` 不带分支名直接被 git 拒绝。
+// 当 SetUpstream=true 且未显式给 Branch 时，仅在 SDK 已确定 target remote 的前提下，
+// 才会通过 git rev-parse 取出当前分支名再拼到 push 命令上（避免 `git push --set-upstream <remote>`
+// 不带分支名被 git 拒绝）。target 未确定（多 remote / 无 remote）时保持原始 `git push` 形态，
+// 让 git 自行报错或走默认语义，避免把分支名误当成 remote 名。
 func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*CommandResult, error) {
 	if opts == nil {
 		opts = &PushOptions{}
@@ -216,19 +218,25 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 		setUpstream = *opts.SetUpstream
 	}
 
-	branch := opts.Branch
-	// `git push --set-upstream <remote>` 不带分支名会被 git 拒绝；当调用方依赖 SDK 默认
-	// "首次 push 自动 set upstream" 的契约时，这里替它补上当前分支名。
-	if setUpstream && branch == "" {
-		name, err := g.currentBranch(ctx, path, &opts.GitOptions)
-		if err != nil {
-			return nil, err
+	// branch 补全延迟到 target 已经解析出来时再做：
+	// 1) target 为空（多 remote / 无 remote）时不要把当前分支名当成 remote 名拼到命令上，
+	//    应保留原始 `git push` 形态让 git 自己报错或走默认语义；
+	// 2) `git push --set-upstream <remote>` 不带分支名会被 git 拒绝，因此当 target 已确定
+	//    且 setUpstream=true、Branch 未指定时，再用 rev-parse 取当前分支名补上。
+	buildArgs := func(target string) ([]string, error) {
+		branch := opts.Branch
+		if target != "" && setUpstream && branch == "" {
+			name, err := g.currentBranch(ctx, path, &opts.GitOptions)
+			if err != nil {
+				return nil, err
+			}
+			branch = name
 		}
-		branch = name
+		// target 为空时关闭 --set-upstream，避免生成 `git push --set-upstream` 这种非法形态。
+		effectiveSetUpstream := setUpstream && target != ""
+		return buildPushArgs(target, branch, effectiveSetUpstream), nil
 	}
-
-	return g.runWithOptionalCredentials(ctx, "push", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
-		func(target string) []string { return buildPushArgs(target, branch, setUpstream) })
+	return g.runWithOptionalCredentials(ctx, "push", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions, buildArgs)
 }
 
 // Pull 从远程拉取变更。
@@ -255,7 +263,7 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 		}
 	}
 	return g.runWithOptionalCredentials(ctx, "pull", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
-		func(target string) []string { return buildPullArgs(target, opts.Branch) })
+		func(target string) ([]string, error) { return buildPullArgs(target, opts.Branch), nil })
 }
 
 // currentBranch 通过 git rev-parse 取出当前 HEAD 指向的分支名。
@@ -281,7 +289,7 @@ func (g *Git) runWithOptionalCredentials(
 	ctx context.Context,
 	sub, path, remote, username, password string,
 	opts *GitOptions,
-	buildArgs func(target string) []string,
+	buildArgs func(target string) ([]string, error),
 ) (*CommandResult, error) {
 	withCreds := username != "" && password != ""
 
@@ -294,7 +302,11 @@ func (g *Git) runWithOptionalCredentials(
 				target = name
 			}
 		}
-		result, err := g.runGit(ctx, sub, buildArgs(target), path, opts)
+		args, err := buildArgs(target)
+		if err != nil {
+			return nil, err
+		}
+		result, err := g.runGit(ctx, sub, args, path, opts)
 		if err != nil {
 			return nil, mapPushPullError(err, sub, username, password)
 		}
@@ -306,9 +318,13 @@ func (g *Git) runWithOptionalCredentials(
 	if err != nil {
 		return nil, err
 	}
+	args, err := buildArgs(remoteName)
+	if err != nil {
+		return nil, err
+	}
 	var result *CommandResult
 	err = g.withRemoteCredentials(ctx, path, remoteName, originalURL, username, password, opts, func() error {
-		r, runErr := g.runGit(ctx, sub, buildArgs(remoteName), path, opts)
+		r, runErr := g.runGit(ctx, sub, args, path, opts)
 		result = r
 		return runErr
 	})

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -311,9 +311,13 @@ func (g *Git) runWithOptionalCredentials(
 	if !withCreds {
 		target := remote
 		if target == "" {
-			if name, ok := g.autoSelectRemote(ctx, path, opts); ok {
-				target = name
+			name, err := g.autoSelectRemote(ctx, path, opts)
+			if err != nil {
+				// `git remote` 自身失败（路径非仓库等）时直接返回原始错误，
+				// 避免被后续 buildArgs 转成误导性的 InvalidArgumentError。
+				return nil, err
 			}
+			target = name
 		}
 		args, err := buildArgs(target)
 		if err != nil {
@@ -347,12 +351,14 @@ func (g *Git) runWithOptionalCredentials(
 	return result, nil
 }
 
-// autoSelectRemote 在仓库恰好有一个 remote 时返回其名字；其他情形（无 remote、多 remote、
-// RPC 错误）返回 ok=false，由调用方决定是否兜底到 git 默认行为。
-func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOptions) (string, bool) {
+// autoSelectRemote 在仓库恰好有一个 remote 时返回 (name, nil)；
+// 仓库为 0 / 多 remote 时返回 ("", nil)，由调用方决定是否兜底到 git 默认行为；
+// `git remote` 自身执行失败（路径不是仓库 / 仓库不可访问 / git 异常）时返回 ("", err)，
+// 避免把真实仓库错误掩盖成"需要显式传 Remote"。
+func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOptions) (string, error) {
 	result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
 	if err != nil {
-		return "", false
+		return "", err
 	}
 	var remotes []string
 	for _, line := range strings.Split(result.Stdout, "\n") {
@@ -361,9 +367,9 @@ func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOption
 		}
 	}
 	if len(remotes) == 1 {
-		return remotes[0], true
+		return remotes[0], nil
 	}
-	return "", false
+	return "", nil
 }
 
 // RemoteAdd 为仓库添加（或在 opts.Overwrite=true 时覆盖）一个 remote。
@@ -631,7 +637,11 @@ func (g *Git) runShell(ctx context.Context, sub, cmd string, opts *GitOptions) (
 
 // buildCommandOptions 将 GitOptions 转换为 CommandOption 列表。
 func buildCommandOptions(opts *GitOptions) []CommandOption {
-	mergedEnvs := make(map[string]string, len(defaultGitEnv)+1)
+	capacity := len(defaultGitEnv)
+	if opts != nil {
+		capacity += len(opts.Envs)
+	}
+	mergedEnvs := make(map[string]string, capacity)
 	cmdOpts := []CommandOption{}
 	if opts != nil {
 		maps.Copy(mergedEnvs, opts.Envs)

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -44,8 +44,8 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 	if opts == nil {
 		opts = &CloneOptions{}
 	}
-	if opts.Password != "" && opts.Username == "" {
-		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git clone."}
+	if (opts.Username == "") != (opts.Password == "") {
+		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git clone, or not at all."}
 	}
 
 	plan, err := buildClonePlan(repoURL, opts.Path, opts.Branch, opts.Depth, opts.Username, opts.Password, opts.DangerouslyStoreCredentials)
@@ -220,8 +220,8 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 	if opts == nil {
 		opts = &PushOptions{}
 	}
-	if opts.Password != "" && opts.Username == "" {
-		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git push."}
+	if (opts.Username == "") != (opts.Password == "") {
+		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git push, or not at all."}
 	}
 	setUpstream := true
 	if opts.SetUpstream != nil {
@@ -265,8 +265,8 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 	if opts == nil {
 		opts = &PullOptions{}
 	}
-	if opts.Password != "" && opts.Username == "" {
-		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git pull."}
+	if (opts.Username == "") != (opts.Password == "") {
+		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git pull, or not at all."}
 	}
 
 	if opts.Remote == "" && opts.Branch == "" {
@@ -402,11 +402,8 @@ func (g *Git) RemoteAdd(ctx context.Context, path, name, repoURL string, opts *R
 		addPhase = buildGitCommand(addArgs, path)
 	}
 
-	// 不需要 fetch 时直接执行 add 阶段。
+	// 不需要 fetch 时直接执行 add 阶段（addPhase 已经覆盖了 add 与 add-or-overwrite 两种形态）。
 	if !opts.Fetch {
-		if !opts.Overwrite {
-			return g.runGit(ctx, "remote", addArgs, path, &opts.GitOptions)
-		}
 		return g.runShell(ctx, "remote", addPhase, &opts.GitOptions)
 	}
 

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -450,8 +450,7 @@ func (g *Git) GetConfig(ctx context.Context, key string, opts *ConfigOptions) (s
 	if err != nil {
 		return "", err
 	}
-	cmd := buildGitCommand([]string{"config", scope, "--get", key}, repoPath)
-	result, err := g.runShell(ctx, "config", cmd, &opts.GitOptions)
+	result, err := g.runGit(ctx, "config", []string{"config", scope, "--get", key}, repoPath, &opts.GitOptions)
 	if err != nil {
 		// `git config --get` 未找到值时退出码为 1，stdout/stderr 为空；其他退出码视为真正的错误。
 		var ce *gitCommandError

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -37,6 +37,15 @@ func newGit(c *Commands) *Git {
 	return &Git{commands: c}
 }
 
+// validateCredentialPair 校验 username 与 password 必须同时提供或同时为空。
+// verb 用于拼装错误消息（"clone" / "push" / "pull"）。
+func validateCredentialPair(verb, username, password string) error {
+	if (username == "") == (password == "") {
+		return nil
+	}
+	return &InvalidArgumentError{Msg: fmt.Sprintf("Username and password must be provided together for git %s, or not at all.", verb)}
+}
+
 // Clone 克隆远程仓库到沙箱中。
 // 当 opts.Username/Password 提供且 opts.DangerouslyStoreCredentials 为 false 时，
 // SDK 会在 clone 完成后通过 git remote set-url 移除 origin URL 中的凭证。
@@ -44,8 +53,8 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 	if opts == nil {
 		opts = &CloneOptions{}
 	}
-	if (opts.Username == "") != (opts.Password == "") {
-		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git clone, or not at all."}
+	if err := validateCredentialPair("clone", opts.Username, opts.Password); err != nil {
+		return nil, err
 	}
 
 	plan, err := buildClonePlan(repoURL, opts.Path, opts.Branch, opts.Depth, opts.Username, opts.Password, opts.DangerouslyStoreCredentials)
@@ -220,21 +229,14 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 	if opts == nil {
 		opts = &PushOptions{}
 	}
-	if (opts.Username == "") != (opts.Password == "") {
-		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git push, or not at all."}
+	if err := validateCredentialPair("push", opts.Username, opts.Password); err != nil {
+		return nil, err
 	}
 	setUpstream := true
 	if opts.SetUpstream != nil {
 		setUpstream = *opts.SetUpstream
 	}
 
-	// branch 补全延迟到 target 已经解析出来时再做：
-	// 1) target 为空（多 remote / 无 remote）但调用方显式给了 Branch 时，直接返回错误：
-	//    `git push <branch>` 在原生 git 里会被解析成 `git push <repository>`，把分支名当 remote 名，
-	//    与 PushOptions.Branch 的对外语义不一致。要求调用方显式补 Remote。
-	// 2) target 为空且 Branch 也未指定时保持原始 `git push` 形态，让 git 走默认语义。
-	// 3) target 已确定且 setUpstream=true、Branch 未指定时，用 rev-parse 取当前分支名补上，
-	//    避免 `git push --set-upstream <remote>` 不带分支名被 git 拒绝。
 	buildArgs := func(target string) ([]string, error) {
 		branch := opts.Branch
 		if target == "" {
@@ -265,8 +267,8 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 	if opts == nil {
 		opts = &PullOptions{}
 	}
-	if (opts.Username == "") != (opts.Password == "") {
-		return nil, &InvalidArgumentError{Msg: "Username and password must be provided together for git pull, or not at all."}
+	if err := validateCredentialPair("pull", opts.Username, opts.Password); err != nil {
+		return nil, err
 	}
 
 	if opts.Remote == "" && opts.Branch == "" {
@@ -366,9 +368,21 @@ func (g *Git) runWithOptionalCredentials(
 // `git remote` 自身执行失败（路径不是仓库 / 仓库不可访问 / git 异常）时返回 ("", err)，
 // 避免把真实仓库错误掩盖成"需要显式传 Remote"。
 func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOptions) (string, error) {
-	result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
+	remotes, err := g.listRemotes(ctx, path, opts)
 	if err != nil {
 		return "", err
+	}
+	if len(remotes) == 1 {
+		return remotes[0], nil
+	}
+	return "", nil
+}
+
+// listRemotes 返回仓库当前配置的全部 remote 名（已去除空行与首尾空白）。
+func (g *Git) listRemotes(ctx context.Context, path string, opts *GitOptions) ([]string, error) {
+	result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
+	if err != nil {
+		return nil, err
 	}
 	var remotes []string
 	for _, line := range strings.Split(result.Stdout, "\n") {
@@ -376,10 +390,7 @@ func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOption
 			remotes = append(remotes, s)
 		}
 	}
-	if len(remotes) == 1 {
-		return remotes[0], nil
-	}
-	return "", nil
+	return remotes, nil
 }
 
 // RemoteAdd 为仓库添加（或在 opts.Overwrite=true 时覆盖）一个 remote。
@@ -402,7 +413,7 @@ func (g *Git) RemoteAdd(ctx context.Context, path, name, repoURL string, opts *R
 		addPhase = buildGitCommand(addArgs, path)
 	}
 
-	// 不需要 fetch 时直接执行 add 阶段（addPhase 已经覆盖了 add 与 add-or-overwrite 两种形态）。
+	// 不需要 fetch 时直接执行 add 阶段。
 	if !opts.Fetch {
 		return g.runShell(ctx, "remote", addPhase, &opts.GitOptions)
 	}
@@ -519,8 +530,6 @@ func (g *Git) DangerouslyAuthenticate(ctx context.Context, opts *AuthenticateOpt
 		"",
 		"",
 	}, "\n")
-	// 把格式串显式包成 '%s'，让 review 工具更容易判定 credentialInput 的 % 等字符
-	// 不会被 printf 解析；shellEscape 已用单引号包裹，原本也不会触发任何二次解析。
 	cmd := fmt.Sprintf("printf '%%s' %s | %s", shellEscape(credentialInput), buildGitCommand([]string{"credential", "approve"}, ""))
 	return g.runShell(ctx, "credential", cmd, &opts.GitOptions)
 }
@@ -569,15 +578,9 @@ func (g *Git) hasUpstream(ctx context.Context, path string, opts *GitOptions) (b
 func (g *Git) resolveRemoteName(ctx context.Context, path, remote string, opts *GitOptions) (string, string, error) {
 	name := remote
 	if name == "" {
-		result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
+		remotes, err := g.listRemotes(ctx, path, opts)
 		if err != nil {
 			return "", "", err
-		}
-		var remotes []string
-		for _, line := range strings.Split(result.Stdout, "\n") {
-			if s := strings.TrimSpace(line); s != "" {
-				remotes = append(remotes, s)
-			}
 		}
 		switch len(remotes) {
 		case 0:

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -389,6 +389,9 @@ func (g *Git) DangerouslyAuthenticate(ctx context.Context, opts *AuthenticateOpt
 	if protocol == "" {
 		protocol = "https"
 	}
+	if protocol != "https" {
+		return nil, &InvalidArgumentError{Msg: "Only https protocol is supported for git authentication."}
+	}
 
 	if _, err := g.runGit(ctx, "config", []string{"config", "--global", "credential.helper", "store"}, "", &opts.GitOptions); err != nil {
 		return nil, err

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -58,7 +58,7 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 	if plan.shouldStrip {
 		// 即使 ctx 已取消也要清理凭证，避免带凭证的 URL 残留在 .git/config。
 		if _, serr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions); serr != nil {
-			return result, serr
+			return result, fmt.Errorf("clone succeeded but failed to strip credentials: %w", serr)
 		}
 	}
 	return result, nil
@@ -244,20 +244,34 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 
 // runWithOptionalCredentials 执行 push/pull 等需要可选凭证注入的远程同步命令。
 // buildArgs 接收已解析的 target remote 名（可为空），返回最终参数列表。
+//
+// remote 解析提到凭证分支之外，确保"带凭证"与"不带凭证"两种调用对单 remote 仓库
+// 有一致的语义：当调用方未显式指定 remote 时，仓库恰好只有一个 remote 会被自动选中。
 func (g *Git) runWithOptionalCredentials(
 	ctx context.Context,
 	sub, path, remote, username, password string,
 	opts *GitOptions,
 	buildArgs func(target string) []string,
 ) (*CommandResult, error) {
-	if username == "" || password == "" {
-		result, err := g.runGit(ctx, sub, buildArgs(remote), path, opts)
+	withCreds := username != "" && password != ""
+
+	// 不带凭证时，对显式 remote 直接使用；未指定 remote 时尝试自动选中唯一 remote，
+	// 若仓库无 remote 或多 remote 则交回 git 自身的默认行为（保持向后兼容，让 git 报错）。
+	if !withCreds {
+		target := remote
+		if target == "" {
+			if name, ok := g.autoSelectRemote(ctx, path, opts); ok {
+				target = name
+			}
+		}
+		result, err := g.runGit(ctx, sub, buildArgs(target), path, opts)
 		if err != nil {
 			return nil, mapPushPullError(err, sub, username, password)
 		}
 		return result, nil
 	}
 
+	// 带凭证时必须解析出确切的 remote 名（含 URL），用于注入/恢复凭证。
 	remoteName, originalURL, err := g.resolveRemoteName(ctx, path, remote, opts)
 	if err != nil {
 		return nil, err
@@ -274,27 +288,56 @@ func (g *Git) runWithOptionalCredentials(
 	return result, nil
 }
 
+// autoSelectRemote 在仓库恰好有一个 remote 时返回其名字；其他情形（无 remote、多 remote、
+// RPC 错误）返回 ok=false，由调用方决定是否兜底到 git 默认行为。
+func (g *Git) autoSelectRemote(ctx context.Context, path string, opts *GitOptions) (string, bool) {
+	result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
+	if err != nil {
+		return "", false
+	}
+	var remotes []string
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			remotes = append(remotes, s)
+		}
+	}
+	if len(remotes) == 1 {
+		return remotes[0], true
+	}
+	return "", false
+}
+
 // RemoteAdd 为仓库添加（或在 opts.Overwrite=true 时覆盖）一个 remote。
 func (g *Git) RemoteAdd(ctx context.Context, path, name, repoURL string, opts *RemoteAddOptions) (*CommandResult, error) {
 	if opts == nil {
 		opts = &RemoteAddOptions{}
 	}
-	addArgs, err := buildRemoteAddArgs(name, repoURL, opts.Fetch)
+	addArgs, err := buildRemoteAddArgs(name, repoURL)
 	if err != nil {
 		return nil, err
 	}
-	if !opts.Overwrite {
-		return g.runGit(ctx, "remote", addArgs, path, &opts.GitOptions)
+
+	// 构造 add-or-overwrite 阶段：不带 fetch，避免 add 失败后 set-url fallback 与 add -f 的语义混淆。
+	var addPhase string
+	if opts.Overwrite {
+		addCmd := buildGitCommand(addArgs, path)
+		setURLCmd := buildGitCommand(buildRemoteSetURLArgs(name, repoURL), path)
+		addPhase = addCmd + " || " + setURLCmd
+	} else {
+		addPhase = buildGitCommand(addArgs, path)
 	}
 
-	addCmd := buildGitCommand(addArgs, path)
-	setURLCmd := buildGitCommand(buildRemoteSetURLArgs(name, repoURL), path)
-	cmd := addCmd + " || " + setURLCmd
-	if opts.Fetch {
-		fetchCmd := buildGitCommand([]string{"fetch", name}, path)
-		cmd = "(" + cmd + ") && " + fetchCmd
+	// 不需要 fetch 时直接执行 add 阶段。
+	if !opts.Fetch {
+		if !opts.Overwrite {
+			return g.runGit(ctx, "remote", addArgs, path, &opts.GitOptions)
+		}
+		return g.runShell(ctx, "remote", addPhase, &opts.GitOptions)
 	}
-	return g.runShell(ctx, "remote", cmd, &opts.GitOptions)
+
+	// 需要 fetch 时统一拼一次：add 阶段成功后仅 fetch 一次，避免重复网络请求。
+	fetchCmd := buildGitCommand([]string{"fetch", name}, path)
+	return g.runShell(ctx, "remote", "("+addPhase+") && "+fetchCmd, &opts.GitOptions)
 }
 
 // RemoteGet 获取指定 remote 的 URL，未配置时返回空字符串。
@@ -500,8 +543,9 @@ func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalU
 	opErr := fn()
 	// 即使 ctx 已取消也要恢复原 URL，避免凭证遗留在 .git/config。
 	_, restoreErr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
+	// 恢复 URL 是安全相关步骤，主操作错误不应吞掉它；用 errors.Join 同时保留两者。
 	if opErr != nil {
-		return opErr
+		return errors.Join(opErr, restoreErr)
 	}
 	return restoreErr
 }

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -219,22 +219,28 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 	}
 
 	// branch 补全延迟到 target 已经解析出来时再做：
-	// 1) target 为空（多 remote / 无 remote）时不要把当前分支名当成 remote 名拼到命令上，
-	//    应保留原始 `git push` 形态让 git 自己报错或走默认语义；
-	// 2) `git push --set-upstream <remote>` 不带分支名会被 git 拒绝，因此当 target 已确定
-	//    且 setUpstream=true、Branch 未指定时，再用 rev-parse 取当前分支名补上。
+	// 1) target 为空（多 remote / 无 remote）但调用方显式给了 Branch 时，直接返回错误：
+	//    `git push <branch>` 在原生 git 里会被解析成 `git push <repository>`，把分支名当 remote 名，
+	//    与 PushOptions.Branch 的对外语义不一致。要求调用方显式补 Remote。
+	// 2) target 为空且 Branch 也未指定时保持原始 `git push` 形态，让 git 走默认语义。
+	// 3) target 已确定且 setUpstream=true、Branch 未指定时，用 rev-parse 取当前分支名补上，
+	//    避免 `git push --set-upstream <remote>` 不带分支名被 git 拒绝。
 	buildArgs := func(target string) ([]string, error) {
 		branch := opts.Branch
-		if target != "" && setUpstream && branch == "" {
+		if target == "" {
+			if branch != "" {
+				return nil, &InvalidArgumentError{Msg: "Remote is required when Branch is specified and the repository does not have a single remote to auto-select."}
+			}
+			return buildPushArgs("", "", false), nil
+		}
+		if setUpstream && branch == "" {
 			name, err := g.currentBranch(ctx, path, &opts.GitOptions)
 			if err != nil {
 				return nil, err
 			}
 			branch = name
 		}
-		// target 为空时关闭 --set-upstream，避免生成 `git push --set-upstream` 这种非法形态。
-		effectiveSetUpstream := setUpstream && target != ""
-		return buildPushArgs(target, branch, effectiveSetUpstream), nil
+		return buildPushArgs(target, branch, setUpstream), nil
 	}
 	return g.runWithOptionalCredentials(ctx, "push", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions, buildArgs)
 }
@@ -263,7 +269,14 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 		}
 	}
 	return g.runWithOptionalCredentials(ctx, "pull", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
-		func(target string) ([]string, error) { return buildPullArgs(target, opts.Branch), nil })
+		func(target string) ([]string, error) {
+			// target 为空但显式给了 Branch 时直接返回错误：
+			// `git pull <branch>` 在 git 里会被解析成 `git pull <repository>`，与对外语义不一致。
+			if target == "" && opts.Branch != "" {
+				return nil, &InvalidArgumentError{Msg: "Remote is required when Branch is specified and the repository does not have a single remote to auto-select."}
+			}
+			return buildPullArgs(target, opts.Branch), nil
+		})
 }
 
 // currentBranch 通过 git rev-parse 取出当前 HEAD 指向的分支名。
@@ -494,7 +507,9 @@ func (g *Git) DangerouslyAuthenticate(ctx context.Context, opts *AuthenticateOpt
 		"",
 		"",
 	}, "\n")
-	cmd := fmt.Sprintf("printf %%s %s | %s", shellEscape(credentialInput), buildGitCommand([]string{"credential", "approve"}, ""))
+	// 把格式串显式包成 '%s'，让 review 工具更容易判定 credentialInput 的 % 等字符
+	// 不会被 printf 解析；shellEscape 已用单引号包裹，原本也不会触发任何二次解析。
+	cmd := fmt.Sprintf("printf '%%s' %s | %s", shellEscape(credentialInput), buildGitCommand([]string{"credential", "approve"}, ""))
 	return g.runShell(ctx, "credential", cmd, &opts.GitOptions)
 }
 
@@ -574,7 +589,7 @@ func (g *Git) resolveRemoteName(ctx context.Context, path, remote string, opts *
 
 // withRemoteCredentials 临时把 username/password 注入指定 remote 的 URL，
 // 在 fn 执行完成后无论成功或失败都恢复原 URL。originalURL 由调用方传入以避免重复 RPC。
-func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalURL, username, password string, opts *GitOptions, fn func() error) error {
+func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalURL, username, password string, opts *GitOptions, fn func() error) (err error) {
 	authedURL, err := withCredentials(originalURL, username, password)
 	if err != nil {
 		return err
@@ -583,17 +598,16 @@ func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalU
 		return fn()
 	}
 
-	if _, err := g.runGit(ctx, "remote", buildRemoteSetURLArgs(remote, authedURL), path, opts); err != nil {
+	if _, err = g.runGit(ctx, "remote", buildRemoteSetURLArgs(remote, authedURL), path, opts); err != nil {
 		return err
 	}
-	opErr := fn()
-	// 即使 ctx 已取消也要恢复原 URL，避免凭证遗留在 .git/config。
-	_, restoreErr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
-	// 恢复 URL 是安全相关步骤，主操作错误不应吞掉它；用 errors.Join 同时保留两者。
-	if opErr != nil {
-		return errors.Join(opErr, restoreErr)
-	}
-	return restoreErr
+	defer func() {
+		// 即使 ctx 已取消也要恢复原 URL，避免凭证遗留在 .git/config。
+		// 恢复 URL 是安全相关步骤，主操作错误不应吞掉它；用 errors.Join 同时保留两者。
+		_, restoreErr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
+		err = errors.Join(err, restoreErr)
+	}()
+	return fn()
 }
 
 // runGit 拼装并执行一条 git 命令。

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -90,12 +90,36 @@ func (g *Git) Status(ctx context.Context, path string, opts *GitOptions) (*GitSt
 }
 
 // Branches 返回仓库的分支列表。
+//
+// unborn 仓库（git init 后尚未提交）下 `git branch` 无任何输出，但 HEAD 已经
+// 指向初始分支；此时退化到 `git symbolic-ref --short HEAD` 取出 CurrentBranch，
+// 与 GitBranches.CurrentBranch "仅在 detached HEAD 时为空" 的契约保持一致。
 func (g *Git) Branches(ctx context.Context, path string, opts *GitOptions) (*GitBranches, error) {
 	result, err := g.runGit(ctx, "branch", buildBranchesArgs(), path, opts)
 	if err != nil {
 		return nil, err
 	}
-	return parseGitBranches(result.Stdout), nil
+	branches := parseGitBranches(result.Stdout)
+	if branches.CurrentBranch == "" && len(branches.Branches) == 0 {
+		if name, ok := g.unbornCurrentBranch(ctx, path, opts); ok {
+			branches.CurrentBranch = name
+		}
+	}
+	return branches, nil
+}
+
+// unbornCurrentBranch 尝试通过 symbolic-ref 读取 unborn 仓库的当前分支名。
+// 仓库为 detached HEAD 或非 git 目录时 symbolic-ref 失败，返回 ok=false。
+func (g *Git) unbornCurrentBranch(ctx context.Context, path string, opts *GitOptions) (string, bool) {
+	result, err := g.runGit(ctx, "symbolic-ref", []string{"symbolic-ref", "--short", "HEAD"}, path, opts)
+	if err != nil {
+		return "", false
+	}
+	name := strings.TrimSpace(result.Stdout)
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 // CreateBranch 创建并切换到新分支。

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -198,6 +198,12 @@ func (g *Git) Restore(ctx context.Context, path string, opts *RestoreOptions) (*
 
 // Push 将提交推送到远程。
 // 当 opts.Username/Password 提供时，SDK 会临时把凭证写入目标 remote URL，命令完成后立即恢复原 URL。
+//
+// 当未显式指定 Remote 时，SDK 会尝试自动选中仓库唯一的 remote（与"自动选择单一 remote"
+// 契约一致）；多 remote / 无 remote 时回退到 git 原生行为或返回带凭证场景下的明确错误。
+//
+// 当 SetUpstream=true 且未显式给 Branch 时，SDK 会通过 git rev-parse 取出当前分支名再
+// 拼到 push 命令上，避免 `git push --set-upstream <remote>` 不带分支名直接被 git 拒绝。
 func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*CommandResult, error) {
 	if opts == nil {
 		opts = &PushOptions{}
@@ -205,28 +211,38 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 	if opts.Password != "" && opts.Username == "" {
 		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git push."}
 	}
-	if opts.Branch != "" && opts.Remote == "" {
-		return nil, &InvalidArgumentError{Msg: "Remote is required when specifying a branch for git push."}
-	}
 	setUpstream := true
 	if opts.SetUpstream != nil {
 		setUpstream = *opts.SetUpstream
 	}
+
+	branch := opts.Branch
+	// `git push --set-upstream <remote>` 不带分支名会被 git 拒绝；当调用方依赖 SDK 默认
+	// "首次 push 自动 set upstream" 的契约时，这里替它补上当前分支名。
+	if setUpstream && branch == "" {
+		name, err := g.currentBranch(ctx, path, &opts.GitOptions)
+		if err != nil {
+			return nil, err
+		}
+		branch = name
+	}
+
 	return g.runWithOptionalCredentials(ctx, "push", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
-		func(target string) []string { return buildPushArgs(target, opts.Branch, setUpstream) })
+		func(target string) []string { return buildPushArgs(target, branch, setUpstream) })
 }
 
 // Pull 从远程拉取变更。
 // 当 opts.Username/Password 提供时，SDK 会临时把凭证写入目标 remote URL，命令完成后立即恢复原 URL。
+//
+// 当未显式指定 Remote 时，SDK 会尝试自动选中仓库唯一的 remote（与"自动选择单一 remote"
+// 契约一致）。当 Remote 与 Branch 都未指定时，SDK 会先检查当前分支是否配置了 upstream，
+// 未配置则直接返回 GitUpstreamError 而不是把模糊错误抛给调用方。
 func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*CommandResult, error) {
 	if opts == nil {
 		opts = &PullOptions{}
 	}
 	if opts.Password != "" && opts.Username == "" {
 		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git pull."}
-	}
-	if opts.Branch != "" && opts.Remote == "" {
-		return nil, &InvalidArgumentError{Msg: "Remote is required when specifying a branch for git pull."}
 	}
 
 	if opts.Remote == "" && opts.Branch == "" {
@@ -240,6 +256,20 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 	}
 	return g.runWithOptionalCredentials(ctx, "pull", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
 		func(target string) []string { return buildPullArgs(target, opts.Branch) })
+}
+
+// currentBranch 通过 git rev-parse 取出当前 HEAD 指向的分支名。
+// detached HEAD 时 rev-parse 返回 "HEAD"，会作为错误向上抛出，避免错误地把字面 "HEAD" 拼到 push 命令上。
+func (g *Git) currentBranch(ctx context.Context, path string, opts *GitOptions) (string, error) {
+	result, err := g.runGit(ctx, "rev-parse", []string{"rev-parse", "--abbrev-ref", "HEAD"}, path, opts)
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(result.Stdout)
+	if name == "" || name == "HEAD" {
+		return "", &InvalidArgumentError{Msg: "Cannot push with SetUpstream=true on a detached HEAD; specify Branch explicitly or set SetUpstream=false."}
+	}
+	return name, nil
 }
 
 // runWithOptionalCredentials 执行 push/pull 等需要可选凭证注入的远程同步命令。

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -7,6 +7,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -55,7 +56,8 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 	}
 
 	if plan.shouldStrip {
-		if _, serr := g.runGit(ctx, "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions); serr != nil {
+		// 即使 ctx 已取消也要清理凭证，避免带凭证的 URL 残留在 .git/config。
+		if _, serr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions); serr != nil {
 			return result, serr
 		}
 	}
@@ -179,6 +181,9 @@ func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*Comman
 	if opts.Password != "" && opts.Username == "" {
 		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git push."}
 	}
+	if opts.Branch != "" && opts.Remote == "" {
+		return nil, &InvalidArgumentError{Msg: "Remote is required when specifying a branch for git push."}
+	}
 	setUpstream := true
 	if opts.SetUpstream != nil {
 		setUpstream = *opts.SetUpstream
@@ -195,6 +200,9 @@ func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*Comman
 	}
 	if opts.Password != "" && opts.Username == "" {
 		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git pull."}
+	}
+	if opts.Branch != "" && opts.Remote == "" {
+		return nil, &InvalidArgumentError{Msg: "Remote is required when specifying a branch for git pull."}
 	}
 
 	if opts.Remote == "" && opts.Branch == "" {
@@ -270,9 +278,13 @@ func (g *Git) RemoteGet(ctx context.Context, path, name string, opts *GitOptions
 	if name == "" {
 		return "", &InvalidArgumentError{Msg: "Remote name is required."}
 	}
-	cmd := buildGitCommand(buildRemoteGetURLArgs(name), path) + " || true"
-	result, err := g.runShell(ctx, "remote", cmd, opts)
+	result, err := g.runGit(ctx, "remote", buildRemoteGetURLArgs(name), path, opts)
 	if err != nil {
+		// `git remote get-url <name>` 在 remote 不存在时退出码为 2；其他退出码视为真正的错误。
+		var ce *gitCommandError
+		if errors.As(err, &ce) && ce.Result != nil && ce.Result.ExitCode == 2 {
+			return "", nil
+		}
 		return "", err
 	}
 	return strings.TrimSpace(result.Stdout), nil
@@ -306,9 +318,15 @@ func (g *Git) GetConfig(ctx context.Context, key string, opts *ConfigOptions) (s
 	if err != nil {
 		return "", err
 	}
-	cmd := buildGitCommand([]string{"config", scope, "--get", key}, repoPath) + " || true"
+	cmd := buildGitCommand([]string{"config", scope, "--get", key}, repoPath)
 	result, err := g.runShell(ctx, "config", cmd, &opts.GitOptions)
 	if err != nil {
+		// `git config --get` 未找到值时退出码为 1，stdout/stderr 为空；其他退出码视为真正的错误。
+		var ce *gitCommandError
+		if errors.As(err, &ce) && ce.Result != nil && ce.Result.ExitCode == 1 &&
+			strings.TrimSpace(ce.Result.Stdout) == "" && strings.TrimSpace(ce.Result.Stderr) == "" {
+			return "", nil
+		}
 		return "", err
 	}
 	return strings.TrimSpace(result.Stdout), nil
@@ -478,7 +496,6 @@ func (g *Git) runShell(ctx context.Context, sub, cmd string, opts *GitOptions) (
 // buildCommandOptions 将 GitOptions 转换为 CommandOption 列表。
 func buildCommandOptions(opts *GitOptions) []CommandOption {
 	mergedEnvs := make(map[string]string, len(defaultGitEnv)+1)
-	maps.Copy(mergedEnvs, defaultGitEnv)
 	cmdOpts := []CommandOption{}
 	if opts != nil {
 		maps.Copy(mergedEnvs, opts.Envs)
@@ -492,6 +509,8 @@ func buildCommandOptions(opts *GitOptions) []CommandOption {
 			cmdOpts = append(cmdOpts, WithTimeout(opts.Timeout))
 		}
 	}
+	// 默认环境必须最后写入，避免被调用方覆盖（例如禁用 GIT_TERMINAL_PROMPT）。
+	maps.Copy(mergedEnvs, defaultGitEnv)
 	cmdOpts = append(cmdOpts, WithEnvs(mergedEnvs))
 	return cmdOpts
 }

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -65,7 +65,7 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 	result, err := g.runGit(ctx, "clone", plan.args, "", &opts.GitOptions)
 	if err != nil {
 		if isAuthFailure(err) {
-			return nil, &GitAuthError{Msg: buildAuthErrorMessage("clone", opts.Username != "" && opts.Password == "")}
+			return nil, &GitAuthError{Msg: buildAuthErrorMessage("clone", opts.Username != "" && opts.Password == ""), Err: err}
 		}
 		return nil, err
 	}
@@ -74,8 +74,8 @@ func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*C
 		// 即使 ctx 已取消也要清理凭证，避免带凭证的 URL 残留在 .git/config。
 		// 用独立的带超时 ctx，防止沙箱异常时无限阻塞。
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), credentialCleanupTimeout)
+		defer cancel()
 		_, serr := g.runGit(cleanupCtx, "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions)
-		cancel()
 		if serr != nil {
 			return result, fmt.Errorf("clone succeeded but failed to strip credentials: %w", serr)
 		}
@@ -679,10 +679,10 @@ func mapPushPullError(err error, action, username, password string) error {
 		return nil
 	}
 	if isAuthFailure(err) {
-		return &GitAuthError{Msg: buildAuthErrorMessage(action, username != "" && password == "")}
+		return &GitAuthError{Msg: buildAuthErrorMessage(action, username != "" && password == ""), Err: err}
 	}
 	if isMissingUpstream(err) {
-		return &GitUpstreamError{Msg: buildUpstreamErrorMessage(action)}
+		return &GitUpstreamError{Msg: buildUpstreamErrorMessage(action), Err: err}
 	}
 	return err
 }

--- a/sandbox/git.go
+++ b/sandbox/git.go
@@ -1,0 +1,511 @@
+// Package sandbox 中的 git.go 提供沙箱内 git 操作的高层封装。
+//
+// Git 操作通过 Commands.Run 调用沙箱内已预装的 git 二进制实现，
+// 仅支持 HTTPS + username/password (token) 形式的认证，不支持 SSH key。
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+)
+
+// defaultGitEnv 是所有 git 命令默认注入的环境变量，用于禁止交互式提示。
+var defaultGitEnv = map[string]string{
+	"GIT_TERMINAL_PROMPT": "0",
+}
+
+// Git 提供沙箱内的 git 操作接口。
+//
+// 仅支持 HTTPS + username/password (token) 认证，不支持 SSH key。
+// 所有命令都会强制注入 GIT_TERMINAL_PROMPT=0 以禁止交互式输入。
+type Git struct {
+	commands *Commands
+}
+
+// newGit 创建 Git 实例。
+func newGit(c *Commands) *Git {
+	return &Git{commands: c}
+}
+
+// Clone 克隆远程仓库到沙箱中。
+// 当 opts.Username/Password 提供且 opts.DangerouslyStoreCredentials 为 false 时，
+// SDK 会在 clone 完成后通过 git remote set-url 移除 origin URL 中的凭证。
+func (g *Git) Clone(ctx context.Context, repoURL string, opts *CloneOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &CloneOptions{}
+	}
+	if opts.Password != "" && opts.Username == "" {
+		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git clone."}
+	}
+
+	plan, err := buildClonePlan(repoURL, opts.Path, opts.Branch, opts.Depth, opts.Username, opts.Password, opts.DangerouslyStoreCredentials)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.runGit(ctx, "clone", plan.args, "", &opts.GitOptions)
+	if err != nil {
+		if isAuthFailure(err) {
+			return nil, &GitAuthError{Msg: buildAuthErrorMessage("clone", opts.Username != "" && opts.Password == "")}
+		}
+		return nil, err
+	}
+
+	if plan.shouldStrip {
+		if _, serr := g.runGit(ctx, "remote", buildRemoteSetURLArgs("origin", plan.sanitizedURL), plan.repoPath, &opts.GitOptions); serr != nil {
+			return result, serr
+		}
+	}
+	return result, nil
+}
+
+// Init 在指定路径初始化新的 git 仓库。
+func (g *Git) Init(ctx context.Context, path string, opts *InitOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &InitOptions{}
+	}
+	args := []string{"init"}
+	if opts.InitialBranch != "" {
+		args = append(args, "--initial-branch", opts.InitialBranch)
+	}
+	if opts.Bare {
+		args = append(args, "--bare")
+	}
+	args = append(args, path)
+	return g.runGit(ctx, "init", args, "", &opts.GitOptions)
+}
+
+// Status 返回仓库状态信息。
+func (g *Git) Status(ctx context.Context, path string, opts *GitOptions) (*GitStatus, error) {
+	result, err := g.runGit(ctx, "status", buildStatusArgs(), path, opts)
+	if err != nil {
+		return nil, err
+	}
+	return parseGitStatus(result.Stdout), nil
+}
+
+// Branches 返回仓库的分支列表。
+func (g *Git) Branches(ctx context.Context, path string, opts *GitOptions) (*GitBranches, error) {
+	result, err := g.runGit(ctx, "branch", buildBranchesArgs(), path, opts)
+	if err != nil {
+		return nil, err
+	}
+	return parseGitBranches(result.Stdout), nil
+}
+
+// CreateBranch 创建并切换到新分支。
+func (g *Git) CreateBranch(ctx context.Context, path, branch string, opts *GitOptions) (*CommandResult, error) {
+	if branch == "" {
+		return nil, &InvalidArgumentError{Msg: "Branch name is required."}
+	}
+	return g.runGit(ctx, "checkout", buildCreateBranchArgs(branch), path, opts)
+}
+
+// CheckoutBranch 切换到已存在的分支。
+func (g *Git) CheckoutBranch(ctx context.Context, path, branch string, opts *GitOptions) (*CommandResult, error) {
+	if branch == "" {
+		return nil, &InvalidArgumentError{Msg: "Branch name is required."}
+	}
+	return g.runGit(ctx, "checkout", buildCheckoutBranchArgs(branch), path, opts)
+}
+
+// DeleteBranch 删除分支。
+func (g *Git) DeleteBranch(ctx context.Context, path, branch string, opts *DeleteBranchOptions) (*CommandResult, error) {
+	if branch == "" {
+		return nil, &InvalidArgumentError{Msg: "Branch name is required."}
+	}
+	if opts == nil {
+		opts = &DeleteBranchOptions{}
+	}
+	return g.runGit(ctx, "branch", buildDeleteBranchArgs(branch, opts.Force), path, &opts.GitOptions)
+}
+
+// Add 暂存指定文件，未指定文件时默认 stage 全部变更。
+func (g *Git) Add(ctx context.Context, path string, opts *AddOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &AddOptions{}
+	}
+	all := true
+	if opts.All != nil {
+		all = *opts.All
+	}
+	return g.runGit(ctx, "add", buildAddArgs(opts.Files, all), path, &opts.GitOptions)
+}
+
+// Commit 在仓库中创建一次提交。
+func (g *Git) Commit(ctx context.Context, path, message string, opts *CommitOptions) (*CommandResult, error) {
+	if message == "" {
+		return nil, &InvalidArgumentError{Msg: "Commit message is required."}
+	}
+	if opts == nil {
+		opts = &CommitOptions{}
+	}
+	return g.runGit(ctx, "commit", buildCommitArgs(message, opts.AuthorName, opts.AuthorEmail, opts.AllowEmpty), path, &opts.GitOptions)
+}
+
+// Reset 重置 HEAD 到指定状态。
+func (g *Git) Reset(ctx context.Context, path string, opts *ResetOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &ResetOptions{}
+	}
+	args, err := buildResetArgs(opts.Mode, opts.Target, opts.Paths)
+	if err != nil {
+		return nil, err
+	}
+	return g.runGit(ctx, "reset", args, path, &opts.GitOptions)
+}
+
+// Restore 恢复工作区文件或取消暂存。
+func (g *Git) Restore(ctx context.Context, path string, opts *RestoreOptions) (*CommandResult, error) {
+	if opts == nil {
+		return nil, &InvalidArgumentError{Msg: "Restore options are required."}
+	}
+	args, err := buildRestoreArgs(opts.Paths, opts.Staged, opts.Worktree, opts.Source)
+	if err != nil {
+		return nil, err
+	}
+	return g.runGit(ctx, "restore", args, path, &opts.GitOptions)
+}
+
+// Push 将提交推送到远程。
+// 当 opts.Username/Password 提供时，SDK 会临时把凭证写入目标 remote URL，命令完成后立即恢复原 URL。
+func (g *Git) Push(ctx context.Context, path string, opts *PushOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &PushOptions{}
+	}
+	if opts.Password != "" && opts.Username == "" {
+		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git push."}
+	}
+	setUpstream := true
+	if opts.SetUpstream != nil {
+		setUpstream = *opts.SetUpstream
+	}
+	return g.runWithOptionalCredentials(ctx, "push", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
+		func(target string) []string { return buildPushArgs(target, opts.Branch, setUpstream) })
+}
+
+// Pull 从远程拉取变更。
+// 当 opts.Username/Password 提供时，SDK 会临时把凭证写入目标 remote URL，命令完成后立即恢复原 URL。
+func (g *Git) Pull(ctx context.Context, path string, opts *PullOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &PullOptions{}
+	}
+	if opts.Password != "" && opts.Username == "" {
+		return nil, &InvalidArgumentError{Msg: "Username is required when using a password or token for git pull."}
+	}
+
+	if opts.Remote == "" && opts.Branch == "" {
+		ok, err := g.hasUpstream(ctx, path, &opts.GitOptions)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, &GitUpstreamError{Msg: buildUpstreamErrorMessage("pull")}
+		}
+	}
+	return g.runWithOptionalCredentials(ctx, "pull", path, opts.Remote, opts.Username, opts.Password, &opts.GitOptions,
+		func(target string) []string { return buildPullArgs(target, opts.Branch) })
+}
+
+// runWithOptionalCredentials 执行 push/pull 等需要可选凭证注入的远程同步命令。
+// buildArgs 接收已解析的 target remote 名（可为空），返回最终参数列表。
+func (g *Git) runWithOptionalCredentials(
+	ctx context.Context,
+	sub, path, remote, username, password string,
+	opts *GitOptions,
+	buildArgs func(target string) []string,
+) (*CommandResult, error) {
+	if username == "" || password == "" {
+		result, err := g.runGit(ctx, sub, buildArgs(remote), path, opts)
+		if err != nil {
+			return nil, mapPushPullError(err, sub, username, password)
+		}
+		return result, nil
+	}
+
+	remoteName, originalURL, err := g.resolveRemoteName(ctx, path, remote, opts)
+	if err != nil {
+		return nil, err
+	}
+	var result *CommandResult
+	err = g.withRemoteCredentials(ctx, path, remoteName, originalURL, username, password, opts, func() error {
+		r, runErr := g.runGit(ctx, sub, buildArgs(remoteName), path, opts)
+		result = r
+		return runErr
+	})
+	if err != nil {
+		return nil, mapPushPullError(err, sub, username, password)
+	}
+	return result, nil
+}
+
+// RemoteAdd 为仓库添加（或在 opts.Overwrite=true 时覆盖）一个 remote。
+func (g *Git) RemoteAdd(ctx context.Context, path, name, repoURL string, opts *RemoteAddOptions) (*CommandResult, error) {
+	if opts == nil {
+		opts = &RemoteAddOptions{}
+	}
+	addArgs, err := buildRemoteAddArgs(name, repoURL, opts.Fetch)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.Overwrite {
+		return g.runGit(ctx, "remote", addArgs, path, &opts.GitOptions)
+	}
+
+	addCmd := buildGitCommand(addArgs, path)
+	setURLCmd := buildGitCommand(buildRemoteSetURLArgs(name, repoURL), path)
+	cmd := addCmd + " || " + setURLCmd
+	if opts.Fetch {
+		fetchCmd := buildGitCommand([]string{"fetch", name}, path)
+		cmd = "(" + cmd + ") && " + fetchCmd
+	}
+	return g.runShell(ctx, "remote", cmd, &opts.GitOptions)
+}
+
+// RemoteGet 获取指定 remote 的 URL，未配置时返回空字符串。
+func (g *Git) RemoteGet(ctx context.Context, path, name string, opts *GitOptions) (string, error) {
+	if name == "" {
+		return "", &InvalidArgumentError{Msg: "Remote name is required."}
+	}
+	cmd := buildGitCommand(buildRemoteGetURLArgs(name), path) + " || true"
+	result, err := g.runShell(ctx, "remote", cmd, opts)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+// SetConfig 设置 git config 值。
+// 使用 GitConfigScopeLocal 时必须同时提供 opts.Path。
+func (g *Git) SetConfig(ctx context.Context, key, value string, opts *ConfigOptions) (*CommandResult, error) {
+	if key == "" {
+		return nil, &InvalidArgumentError{Msg: "Git config key is required."}
+	}
+	if opts == nil {
+		opts = &ConfigOptions{}
+	}
+	scope, repoPath, err := resolveConfigScope(opts.Scope, opts.Path)
+	if err != nil {
+		return nil, err
+	}
+	return g.runGit(ctx, "config", []string{"config", scope, key, value}, repoPath, &opts.GitOptions)
+}
+
+// GetConfig 获取 git config 值，未配置时返回空字符串。
+func (g *Git) GetConfig(ctx context.Context, key string, opts *ConfigOptions) (string, error) {
+	if key == "" {
+		return "", &InvalidArgumentError{Msg: "Git config key is required."}
+	}
+	if opts == nil {
+		opts = &ConfigOptions{}
+	}
+	scope, repoPath, err := resolveConfigScope(opts.Scope, opts.Path)
+	if err != nil {
+		return "", err
+	}
+	cmd := buildGitCommand([]string{"config", scope, "--get", key}, repoPath) + " || true"
+	result, err := g.runShell(ctx, "config", cmd, &opts.GitOptions)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+// ConfigureUser 设置 git 提交用户名与邮箱（一次 RPC 内完成）。
+func (g *Git) ConfigureUser(ctx context.Context, name, email string, opts *ConfigOptions) (*CommandResult, error) {
+	if name == "" || email == "" {
+		return nil, &InvalidArgumentError{Msg: "Both name and email are required."}
+	}
+	if opts == nil {
+		opts = &ConfigOptions{}
+	}
+	scope, repoPath, err := resolveConfigScope(opts.Scope, opts.Path)
+	if err != nil {
+		return nil, err
+	}
+	nameCmd := buildGitCommand([]string{"config", scope, "user.name", name}, repoPath)
+	emailCmd := buildGitCommand([]string{"config", scope, "user.email", email}, repoPath)
+	return g.runShell(ctx, "config", nameCmd+" && "+emailCmd, &opts.GitOptions)
+}
+
+// DangerouslyAuthenticate 通过 git credential helper 将凭证持久化到磁盘。
+//
+// 该方法会为后续所有 git 操作生效；建议优先使用短生命周期 token，并谨慎使用此方法。
+func (g *Git) DangerouslyAuthenticate(ctx context.Context, opts *AuthenticateOptions) (*CommandResult, error) {
+	if opts == nil || opts.Username == "" || opts.Password == "" {
+		return nil, &InvalidArgumentError{Msg: "Both username and password are required to authenticate git."}
+	}
+
+	host := strings.TrimSpace(opts.Host)
+	if host == "" {
+		host = "github.com"
+	}
+	protocol := strings.TrimSpace(opts.Protocol)
+	if protocol == "" {
+		protocol = "https"
+	}
+
+	if _, err := g.runGit(ctx, "config", []string{"config", "--global", "credential.helper", "store"}, "", &opts.GitOptions); err != nil {
+		return nil, err
+	}
+
+	credentialInput := strings.Join([]string{
+		"protocol=" + protocol,
+		"host=" + host,
+		"username=" + opts.Username,
+		"password=" + opts.Password,
+		"",
+		"",
+	}, "\n")
+	cmd := fmt.Sprintf("printf %%s %s | %s", shellEscape(credentialInput), buildGitCommand([]string{"credential", "approve"}, ""))
+	return g.runShell(ctx, "credential", cmd, &opts.GitOptions)
+}
+
+// resolveConfigScope 校验并返回 git config 的 scope 标志与仓库路径。
+func resolveConfigScope(scope GitConfigScope, repoPath string) (string, string, error) {
+	if scope == "" {
+		scope = GitConfigScopeGlobal
+	}
+	switch scope {
+	case GitConfigScopeGlobal:
+		return "--global", "", nil
+	case GitConfigScopeSystem:
+		return "--system", "", nil
+	case GitConfigScopeLocal:
+		if repoPath == "" {
+			return "", "", &InvalidArgumentError{Msg: "Repository path is required for local git config scope."}
+		}
+		return "--local", repoPath, nil
+	}
+	return "", "", &InvalidArgumentError{Msg: "Unsupported git config scope: " + string(scope)}
+}
+
+// hasUpstream 检查当前分支是否配置了 upstream。
+func (g *Git) hasUpstream(ctx context.Context, path string, opts *GitOptions) (bool, error) {
+	cmd := buildGitCommand(buildHasUpstreamArgs(), path) + " >/dev/null 2>&1 && echo yes || echo no"
+	result, err := g.runShell(ctx, "rev-parse", cmd, opts)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.Stdout) == "yes", nil
+}
+
+// resolveRemoteName 在凭证注入流程中确定要使用的 remote 名，并一并返回其 URL。
+//
+// 解析规则与 E2B 对齐：
+//   - 显式指定 remote 时直接使用。
+//   - 未指定时通过 `git remote` 列出全部 remote：恰好一个时自动使用，多个时报错（要求显式指定）。
+//
+// 一并返回 URL 是为了让 withRemoteCredentials 复用，避免再发一次 RPC。
+func (g *Git) resolveRemoteName(ctx context.Context, path, remote string, opts *GitOptions) (string, string, error) {
+	name := remote
+	if name == "" {
+		result, err := g.runGit(ctx, "remote", []string{"remote"}, path, opts)
+		if err != nil {
+			return "", "", err
+		}
+		var remotes []string
+		for _, line := range strings.Split(result.Stdout, "\n") {
+			if s := strings.TrimSpace(line); s != "" {
+				remotes = append(remotes, s)
+			}
+		}
+		switch len(remotes) {
+		case 0:
+			return "", "", &InvalidArgumentError{Msg: "Repository has no remote configured."}
+		case 1:
+			name = remotes[0]
+		default:
+			return "", "", &InvalidArgumentError{Msg: "Remote is required when using username/password and the repository has multiple remotes."}
+		}
+	}
+
+	url, err := g.RemoteGet(ctx, path, name, opts)
+	if err != nil {
+		return "", "", err
+	}
+	if url == "" {
+		return "", "", &InvalidArgumentError{Msg: fmt.Sprintf("Remote %q is not configured.", name)}
+	}
+	return name, url, nil
+}
+
+// withRemoteCredentials 临时把 username/password 注入指定 remote 的 URL，
+// 在 fn 执行完成后无论成功或失败都恢复原 URL。originalURL 由调用方传入以避免重复 RPC。
+func (g *Git) withRemoteCredentials(ctx context.Context, path, remote, originalURL, username, password string, opts *GitOptions, fn func() error) error {
+	authedURL, err := withCredentials(originalURL, username, password)
+	if err != nil {
+		return err
+	}
+	if authedURL == originalURL {
+		return fn()
+	}
+
+	if _, err := g.runGit(ctx, "remote", buildRemoteSetURLArgs(remote, authedURL), path, opts); err != nil {
+		return err
+	}
+	opErr := fn()
+	// 即使 ctx 已取消也要恢复原 URL，避免凭证遗留在 .git/config。
+	_, restoreErr := g.runGit(context.Background(), "remote", buildRemoteSetURLArgs(remote, originalURL), path, opts)
+	if opErr != nil {
+		return opErr
+	}
+	return restoreErr
+}
+
+// runGit 拼装并执行一条 git 命令。
+func (g *Git) runGit(ctx context.Context, sub string, args []string, repoPath string, opts *GitOptions) (*CommandResult, error) {
+	cmd := buildGitCommand(args, repoPath)
+	return g.runShell(ctx, sub, cmd, opts)
+}
+
+// runShell 以 shell 形式执行命令，统一注入默认 git 环境变量。
+func (g *Git) runShell(ctx context.Context, sub, cmd string, opts *GitOptions) (*CommandResult, error) {
+	cmdOpts := buildCommandOptions(opts)
+	result, err := g.commands.Run(ctx, cmd, cmdOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w", sub, err)
+	}
+	if result.ExitCode != 0 {
+		return result, &gitCommandError{Cmd: sub, Result: result}
+	}
+	return result, nil
+}
+
+// buildCommandOptions 将 GitOptions 转换为 CommandOption 列表。
+func buildCommandOptions(opts *GitOptions) []CommandOption {
+	mergedEnvs := make(map[string]string, len(defaultGitEnv)+1)
+	maps.Copy(mergedEnvs, defaultGitEnv)
+	cmdOpts := []CommandOption{}
+	if opts != nil {
+		maps.Copy(mergedEnvs, opts.Envs)
+		if opts.User != "" {
+			cmdOpts = append(cmdOpts, WithCommandUser(opts.User))
+		}
+		if opts.Cwd != "" {
+			cmdOpts = append(cmdOpts, WithCwd(opts.Cwd))
+		}
+		if opts.Timeout > 0 {
+			cmdOpts = append(cmdOpts, WithTimeout(opts.Timeout))
+		}
+	}
+	cmdOpts = append(cmdOpts, WithEnvs(mergedEnvs))
+	return cmdOpts
+}
+
+// mapPushPullError 将 push/pull 的命令错误映射为类型化 git 错误。
+func mapPushPullError(err error, action, username, password string) error {
+	if err == nil {
+		return nil
+	}
+	if isAuthFailure(err) {
+		return &GitAuthError{Msg: buildAuthErrorMessage(action, username != "" && password == "")}
+	}
+	if isMissingUpstream(err) {
+		return &GitUpstreamError{Msg: buildUpstreamErrorMessage(action)}
+	}
+	return err
+}

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -55,16 +55,11 @@ func buildPullArgs(target, branch string) []string {
 }
 
 // buildRemoteAddArgs 构造 git remote add 命令的参数列表。
-func buildRemoteAddArgs(name, url string, fetch bool) ([]string, error) {
+func buildRemoteAddArgs(name, url string) ([]string, error) {
 	if name == "" || url == "" {
 		return nil, &InvalidArgumentError{Msg: "Both remote name and URL are required to add a git remote."}
 	}
-	args := []string{"remote", "add"}
-	if fetch {
-		args = append(args, "-f")
-	}
-	args = append(args, name, url)
-	return args, nil
+	return []string{"remote", "add", name, url}, nil
 }
 
 // buildRemoteSetURLArgs 构造 git remote set-url 命令的参数列表。

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -231,6 +231,11 @@ type clonePlan struct {
 
 // buildClonePlan 构造 clone 命令的参数与凭证剥离元信息。
 func buildClonePlan(rawURL, path, branch string, depth int, username, password string, dangerouslyStore bool) (*clonePlan, error) {
+	// 调用方直接把凭证嵌入 URL 时也强制要求 https，与 withCredentials 注入路径保持一致的安全边界，
+	// 避免 `http://user:pass@host/...` 这类绕过明文走 HTTP。
+	if err := requireHTTPSIfHasCredentials(rawURL); err != nil {
+		return nil, err
+	}
 	cloneURL := rawURL
 	if username != "" && password != "" {
 		var err error

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -1,0 +1,273 @@
+package sandbox
+
+import (
+	"strconv"
+	"strings"
+)
+
+// shellEscape 对字符串做 shell 单引号转义，使其可安全嵌入命令字符串。
+func shellEscape(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+// buildGitCommand 拼装一条 shell 安全的 git 命令字符串。
+// repoPath 非空时附加 -C <repoPath>。
+func buildGitCommand(args []string, repoPath string) string {
+	parts := make([]string, 0, len(args)+3)
+	parts = append(parts, "git")
+	if repoPath != "" {
+		parts = append(parts, "-C", repoPath)
+	}
+	parts = append(parts, args...)
+	for i, p := range parts {
+		parts[i] = shellEscape(p)
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildPushArgs 构造 git push 命令的参数列表。
+// target 为最终使用的 remote 名（已合并 remoteName 与 remote 选项）。
+func buildPushArgs(target, branch string, setUpstream bool) []string {
+	args := []string{"push"}
+	if setUpstream && target != "" {
+		args = append(args, "--set-upstream")
+	}
+	if target != "" {
+		args = append(args, target)
+	}
+	if branch != "" {
+		args = append(args, branch)
+	}
+	return args
+}
+
+// buildPullArgs 构造 git pull 命令的参数列表。
+// target 为最终使用的 remote 名。
+func buildPullArgs(target, branch string) []string {
+	args := []string{"pull"}
+	if target != "" {
+		args = append(args, target)
+	}
+	if branch != "" {
+		args = append(args, branch)
+	}
+	return args
+}
+
+// buildRemoteAddArgs 构造 git remote add 命令的参数列表。
+func buildRemoteAddArgs(name, url string, fetch bool) ([]string, error) {
+	if name == "" || url == "" {
+		return nil, &InvalidArgumentError{Msg: "Both remote name and URL are required to add a git remote."}
+	}
+	args := []string{"remote", "add"}
+	if fetch {
+		args = append(args, "-f")
+	}
+	args = append(args, name, url)
+	return args, nil
+}
+
+// buildRemoteSetURLArgs 构造 git remote set-url 命令的参数列表。
+func buildRemoteSetURLArgs(name, url string) []string {
+	return []string{"remote", "set-url", name, url}
+}
+
+// buildRemoteGetURLArgs 构造 git remote get-url 命令的参数列表。
+func buildRemoteGetURLArgs(name string) []string {
+	return []string{"remote", "get-url", name}
+}
+
+// buildHasUpstreamArgs 构造 upstream 检查命令的参数列表。
+func buildHasUpstreamArgs() []string {
+	return []string{"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"}
+}
+
+// buildStatusArgs 构造 git status 命令的参数列表。
+func buildStatusArgs() []string {
+	return []string{"status", "--porcelain=1", "-b"}
+}
+
+// buildBranchesArgs 构造 git branch 列表命令的参数列表。
+func buildBranchesArgs() []string {
+	return []string{"branch", "--format=%(refname:short)\t%(HEAD)"}
+}
+
+// buildCreateBranchArgs 构造 git checkout -b 命令的参数列表。
+func buildCreateBranchArgs(branch string) []string {
+	return []string{"checkout", "-b", branch}
+}
+
+// buildCheckoutBranchArgs 构造 git checkout 命令的参数列表。
+func buildCheckoutBranchArgs(branch string) []string {
+	return []string{"checkout", branch}
+}
+
+// buildDeleteBranchArgs 构造 git branch 删除命令的参数列表。
+func buildDeleteBranchArgs(branch string, force bool) []string {
+	flag := "-d"
+	if force {
+		flag = "-D"
+	}
+	return []string{"branch", flag, branch}
+}
+
+// buildAddArgs 构造 git add 命令的参数列表。
+func buildAddArgs(files []string, all bool) []string {
+	args := []string{"add"}
+	if len(files) == 0 {
+		if all {
+			args = append(args, "-A")
+		} else {
+			args = append(args, ".")
+		}
+		return args
+	}
+	args = append(args, "--")
+	args = append(args, files...)
+	return args
+}
+
+// buildCommitArgs 构造 git commit 命令的参数列表。
+func buildCommitArgs(message, authorName, authorEmail string, allowEmpty bool) []string {
+	args := []string{"commit", "-m", message}
+	if allowEmpty {
+		args = append(args, "--allow-empty")
+	}
+	var prefix []string
+	if authorName != "" {
+		prefix = append(prefix, "-c", "user.name="+authorName)
+	}
+	if authorEmail != "" {
+		prefix = append(prefix, "-c", "user.email="+authorEmail)
+	}
+	if len(prefix) > 0 {
+		return append(prefix, args...)
+	}
+	return args
+}
+
+// allowedResetModes 是 git reset 允许的模式集合。
+var allowedResetModes = map[GitResetMode]struct{}{
+	GitResetModeSoft:  {},
+	GitResetModeMixed: {},
+	GitResetModeHard:  {},
+	GitResetModeMerge: {},
+	GitResetModeKeep:  {},
+}
+
+// buildResetArgs 构造 git reset 命令的参数列表。
+func buildResetArgs(mode GitResetMode, target string, paths []string) ([]string, error) {
+	if mode != "" {
+		if _, ok := allowedResetModes[mode]; !ok {
+			return nil, &InvalidArgumentError{Msg: "Reset mode must be one of soft, mixed, hard, merge, keep."}
+		}
+	}
+	args := []string{"reset"}
+	if mode != "" {
+		args = append(args, "--"+string(mode))
+	}
+	if target != "" {
+		args = append(args, target)
+	}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	return args, nil
+}
+
+// buildRestoreArgs 构造 git restore 命令的参数列表。
+// 当 staged 与 worktree 均为 nil 时默认仅恢复工作区。
+func buildRestoreArgs(paths []string, staged, worktree *bool, source string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, &InvalidArgumentError{Msg: "At least one path is required."}
+	}
+
+	resolvedStaged := staged
+	resolvedWorktree := worktree
+	switch {
+	case staged == nil && worktree == nil:
+		t := true
+		resolvedWorktree = &t
+	case staged != nil && *staged && worktree == nil:
+		f := false
+		resolvedWorktree = &f
+	case staged == nil && worktree != nil:
+		f := false
+		resolvedStaged = &f
+	}
+
+	stagedOn := resolvedStaged != nil && *resolvedStaged
+	worktreeOn := resolvedWorktree != nil && *resolvedWorktree
+	if !stagedOn && !worktreeOn {
+		return nil, &InvalidArgumentError{Msg: "At least one of staged or worktree must be true."}
+	}
+
+	args := []string{"restore"}
+	if worktreeOn {
+		args = append(args, "--worktree")
+	}
+	if stagedOn {
+		args = append(args, "--staged")
+	}
+	if source != "" {
+		args = append(args, "--source", source)
+	}
+	args = append(args, "--")
+	args = append(args, paths...)
+	return args, nil
+}
+
+// clonePlan 描述一次 clone 的完整执行计划。
+type clonePlan struct {
+	// args 是 git clone 命令的参数列表。
+	args []string
+	// repoPath 是用于 post-clone 调整的仓库路径。
+	repoPath string
+	// sanitizedURL 是凭证剥离后的 URL，用于 clone 后重置 origin。
+	sanitizedURL string
+	// shouldStrip 表示是否需要在 clone 完成后重置 origin URL。
+	shouldStrip bool
+}
+
+// buildClonePlan 构造 clone 命令的参数与凭证剥离元信息。
+func buildClonePlan(rawURL, path, branch string, depth int, username, password string, dangerouslyStore bool) (*clonePlan, error) {
+	cloneURL := rawURL
+	if username != "" && password != "" {
+		var err error
+		cloneURL, err = withCredentials(rawURL, username, password)
+		if err != nil {
+			return nil, err
+		}
+	}
+	sanitized := stripCredentials(cloneURL)
+	shouldStrip := !dangerouslyStore && sanitized != cloneURL
+
+	repoPath := path
+	if shouldStrip {
+		if repoPath == "" {
+			repoPath = deriveRepoDirFromURL(rawURL)
+		}
+		if repoPath == "" {
+			return nil, &InvalidArgumentError{Msg: "A destination path is required when using credentials without storing them."}
+		}
+	}
+
+	args := []string{"clone", cloneURL}
+	if branch != "" {
+		args = append(args, "--branch", branch, "--single-branch")
+	}
+	if depth > 0 {
+		args = append(args, "--depth", strconv.Itoa(depth))
+	}
+	if path != "" {
+		args = append(args, path)
+	}
+
+	plan := &clonePlan{args: args, repoPath: repoPath}
+	if shouldStrip {
+		plan.sanitizedURL = sanitized
+		plan.shouldStrip = true
+	}
+	return plan, nil
+}

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -156,11 +156,15 @@ var allowedResetModes = map[GitResetMode]struct{}{
 }
 
 // buildResetArgs 构造 git reset 命令的参数列表。
+// git reset 的两种用法互斥：带 mode 时重置 HEAD/索引/工作区，带 paths 时仅取消暂存路径。
 func buildResetArgs(mode GitResetMode, target string, paths []string) ([]string, error) {
 	if mode != "" {
 		if _, ok := allowedResetModes[mode]; !ok {
 			return nil, &InvalidArgumentError{Msg: "Reset mode must be one of soft, mixed, hard, merge, keep."}
 		}
+	}
+	if mode != "" && len(paths) > 0 {
+		return nil, &InvalidArgumentError{Msg: "Reset mode and paths cannot be used together."}
 	}
 	args := []string{"reset"}
 	if mode != "" {

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -176,14 +176,8 @@ func buildResetArgs(mode GitResetMode, target string, paths []string) ([]string,
 }
 
 // buildRestoreArgs 构造 git restore 命令的参数列表。
-//
-// staged / worktree 的默认值规则（与"git restore 未指定标志时仅恢复工作区"对齐）：
-//   - 两者均为 nil → 默认 --worktree
-//   - 仅指定 staged=&true → 仅 --staged（不再隐式带 --worktree）
-//   - 仅指定 worktree=&true → 仅 --worktree（不再隐式带 --staged）
-//   - 仅指定 staged=&false 或 worktree=&false → 视作"用户没要求开这个，但也没开另一个"，
-//     退化到默认 --worktree，避免对调用方抛"必须有一个为 true"的语义错误
-//   - 显式两者都为 false → 返回参数错误（没有可执行的恢复目标）
+// 与原生 git 对齐：未显式指定标志时默认仅恢复工作区；任一标志显式 false、另一标志未指定时
+// 也退化到默认 worktree，避免对调用方抛"必须有一个为 true"的语义错。显式两者都为 false 才报错。
 func buildRestoreArgs(paths []string, staged, worktree *bool, source string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, &InvalidArgumentError{Msg: "At least one path is required."}
@@ -191,12 +185,7 @@ func buildRestoreArgs(paths []string, staged, worktree *bool, source string) ([]
 
 	stagedOn := staged != nil && *staged
 	worktreeOn := worktree != nil && *worktree
-	switch {
-	case staged == nil && worktree == nil:
-		// 两者都没指定，按 git 默认仅恢复工作区。
-		worktreeOn = true
-	case !stagedOn && !worktreeOn && (staged == nil || worktree == nil):
-		// 一边显式 false、另一边未指定时，退化到默认 worktree。
+	if !stagedOn && !worktreeOn && (staged == nil || worktree == nil) {
 		worktreeOn = true
 	}
 

--- a/sandbox/git_args.go
+++ b/sandbox/git_args.go
@@ -176,28 +176,30 @@ func buildResetArgs(mode GitResetMode, target string, paths []string) ([]string,
 }
 
 // buildRestoreArgs 构造 git restore 命令的参数列表。
-// 当 staged 与 worktree 均为 nil 时默认仅恢复工作区。
+//
+// staged / worktree 的默认值规则（与"git restore 未指定标志时仅恢复工作区"对齐）：
+//   - 两者均为 nil → 默认 --worktree
+//   - 仅指定 staged=&true → 仅 --staged（不再隐式带 --worktree）
+//   - 仅指定 worktree=&true → 仅 --worktree（不再隐式带 --staged）
+//   - 仅指定 staged=&false 或 worktree=&false → 视作"用户没要求开这个，但也没开另一个"，
+//     退化到默认 --worktree，避免对调用方抛"必须有一个为 true"的语义错误
+//   - 显式两者都为 false → 返回参数错误（没有可执行的恢复目标）
 func buildRestoreArgs(paths []string, staged, worktree *bool, source string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, &InvalidArgumentError{Msg: "At least one path is required."}
 	}
 
-	resolvedStaged := staged
-	resolvedWorktree := worktree
+	stagedOn := staged != nil && *staged
+	worktreeOn := worktree != nil && *worktree
 	switch {
 	case staged == nil && worktree == nil:
-		t := true
-		resolvedWorktree = &t
-	case staged != nil && *staged && worktree == nil:
-		f := false
-		resolvedWorktree = &f
-	case staged == nil && worktree != nil:
-		f := false
-		resolvedStaged = &f
+		// 两者都没指定，按 git 默认仅恢复工作区。
+		worktreeOn = true
+	case !stagedOn && !worktreeOn && (staged == nil || worktree == nil):
+		// 一边显式 false、另一边未指定时，退化到默认 worktree。
+		worktreeOn = true
 	}
 
-	stagedOn := resolvedStaged != nil && *resolvedStaged
-	worktreeOn := resolvedWorktree != nil && *resolvedWorktree
 	if !stagedOn && !worktreeOn {
 		return nil, &InvalidArgumentError{Msg: "At least one of staged or worktree must be true."}
 	}

--- a/sandbox/git_auth.go
+++ b/sandbox/git_auth.go
@@ -1,0 +1,157 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// GitAuthError 表示 git 操作因认证失败而中断。
+type GitAuthError struct {
+	// Msg 是错误消息。
+	Msg string
+}
+
+// Error 实现 error 接口。
+func (e *GitAuthError) Error() string { return e.Msg }
+
+// GitUpstreamError 表示 git 操作因缺少 upstream 跟踪分支而中断。
+type GitUpstreamError struct {
+	// Msg 是错误消息。
+	Msg string
+}
+
+// Error 实现 error 接口。
+func (e *GitUpstreamError) Error() string { return e.Msg }
+
+// InvalidArgumentError 表示传入的参数非法。
+type InvalidArgumentError struct {
+	// Msg 是错误消息。
+	Msg string
+}
+
+// Error 实现 error 接口。
+func (e *InvalidArgumentError) Error() string { return e.Msg }
+
+// withCredentials 将 HTTPS 凭证嵌入 git 仓库 URL 中。
+// 仅 http/https 协议有效；当 username 与 password 均为空时直接返回原 URL。
+func withCredentials(rawURL, username, password string) (string, error) {
+	if username == "" && password == "" {
+		return rawURL, nil
+	}
+	if username == "" || password == "" {
+		return "", &InvalidArgumentError{Msg: "Both username and password are required when using Git credentials."}
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse git url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", &InvalidArgumentError{Msg: "Only http(s) Git URLs support username/password credentials."}
+	}
+
+	u.User = url.UserPassword(username, password)
+	return u.String(), nil
+}
+
+// stripCredentials 从 git URL 中移除已嵌入的凭证。
+// 解析失败或非 http(s) URL 时原样返回。
+func stripCredentials(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return rawURL
+	}
+	if u.User == nil {
+		return rawURL
+	}
+	u.User = nil
+	return u.String()
+}
+
+// authFailureSnippets 是常见的 git 认证失败关键字（小写匹配）。
+var authFailureSnippets = []string{
+	"authentication failed",
+	"terminal prompts disabled",
+	"could not read username",
+	"invalid username or password",
+	"access denied",
+	"permission denied",
+	"not authorized",
+}
+
+// upstreamFailureSnippets 是常见的 git 缺失 upstream 关键字（小写匹配）。
+var upstreamFailureSnippets = []string{
+	"has no upstream branch",
+	"no upstream branch",
+	"no upstream configured",
+	"no tracking information for the current branch",
+	"no tracking information",
+	"set the remote as upstream",
+	"set the upstream branch",
+	"please specify which branch you want to merge with",
+}
+
+// gitCommandError 是内部使用的 git 命令失败错误，附带 stdout/stderr 以便后续匹配。
+type gitCommandError struct {
+	// Cmd 是失败的 git 子命令名（如 "clone"、"push"）。
+	Cmd string
+	// Result 是底层命令的执行结果，包含 ExitCode/Stdout/Stderr。
+	Result *CommandResult
+}
+
+// Error 实现 error 接口。
+func (e *gitCommandError) Error() string {
+	if e.Result == nil {
+		return fmt.Sprintf("git %s failed", e.Cmd)
+	}
+	if stderr := strings.TrimSpace(e.Result.Stderr); stderr != "" {
+		return fmt.Sprintf("git %s failed (exit %d): %s", e.Cmd, e.Result.ExitCode, stderr)
+	}
+	return fmt.Sprintf("git %s failed (exit %d)", e.Cmd, e.Result.ExitCode)
+}
+
+// matchSnippets 在 git 命令错误的 stdout+stderr 中匹配关键字（小写匹配）。
+func matchSnippets(err error, snippets []string) bool {
+	var ge *gitCommandError
+	if !errors.As(err, &ge) || ge.Result == nil {
+		return false
+	}
+	message := strings.ToLower(ge.Result.Stderr + "\n" + ge.Result.Stdout)
+	for _, s := range snippets {
+		if strings.Contains(message, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAuthFailure 判断错误是否由 git 认证失败引起。
+func isAuthFailure(err error) bool { return matchSnippets(err, authFailureSnippets) }
+
+// isMissingUpstream 判断错误是否由缺失 upstream 跟踪引起。
+func isMissingUpstream(err error) bool { return matchSnippets(err, upstreamFailureSnippets) }
+
+// buildAuthErrorMessage 根据动作名构造 git 认证错误消息。
+func buildAuthErrorMessage(action string, missingPassword bool) string {
+	if missingPassword {
+		return fmt.Sprintf("Git %s requires a password/token for private repositories.", action)
+	}
+	return fmt.Sprintf("Git %s requires credentials for private repositories.", action)
+}
+
+// buildUpstreamErrorMessage 根据动作名构造缺失 upstream 的错误消息。
+func buildUpstreamErrorMessage(action string) string {
+	if action == "push" {
+		return "Git push failed because no upstream branch is configured. " +
+			"Set upstream once with SetUpstream=true (and optional Remote/Branch), " +
+			"or pass Remote and Branch explicitly."
+	}
+	return "Git pull failed because no upstream branch is configured. " +
+		"Pass Remote and Branch explicitly, or set upstream once (push with " +
+		"SetUpstream=true or run: git branch --set-upstream-to=origin/<branch> <branch>)."
+}

--- a/sandbox/git_auth.go
+++ b/sandbox/git_auth.go
@@ -35,7 +35,10 @@ type InvalidArgumentError struct {
 func (e *InvalidArgumentError) Error() string { return e.Msg }
 
 // withCredentials 将 HTTPS 凭证嵌入 git 仓库 URL 中。
-// 仅 http/https 协议有效；当 username 与 password 均为空时直接返回原 URL。
+// 仅 https 协议有效；当 username 与 password 均为空时直接返回原 URL。
+//
+// 故意不允许 http：把 token / 密码塞进明文 URL 会让凭证暴露在非 TLS 链路上，
+// 与对外"仅支持 HTTPS + username/password"的承诺一致。
 func withCredentials(rawURL, username, password string) (string, error) {
 	if username == "" && password == "" {
 		return rawURL, nil
@@ -48,8 +51,8 @@ func withCredentials(rawURL, username, password string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse git url: %w", err)
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", &InvalidArgumentError{Msg: "Only http(s) Git URLs support username/password credentials."}
+	if u.Scheme != "https" {
+		return "", &InvalidArgumentError{Msg: "Only https Git URLs support username/password credentials."}
 	}
 
 	u.User = url.UserPassword(username, password)
@@ -74,14 +77,20 @@ func stripCredentials(rawURL string) string {
 }
 
 // authFailureSnippets 是常见的 git 认证失败关键字（小写匹配）。
+//
+// 这里只放与"凭证"语义强相关的关键字，避免把通用的 "permission denied"
+// （工作树目录无写权限、.git/config 权限异常、锁文件权限问题等）误判为
+// 认证失败而把调用方导向错误的排障方向。
 var authFailureSnippets = []string{
 	"authentication failed",
 	"terminal prompts disabled",
 	"could not read username",
+	"could not read password",
 	"invalid username or password",
-	"access denied",
-	"permission denied",
-	"not authorized",
+	"bad credentials",
+	"requested url returned error: 401",
+	"requested url returned error: 403",
+	"http basic: access denied",
 }
 
 // upstreamFailureSnippets 是常见的 git 缺失 upstream 关键字（小写匹配）。

--- a/sandbox/git_auth.go
+++ b/sandbox/git_auth.go
@@ -76,6 +76,19 @@ func stripCredentials(rawURL string) string {
 	return u.String()
 }
 
+// requireHTTPSIfHasCredentials 校验 URL 在内嵌凭证时必须使用 https。
+// 解析失败或未内嵌凭证时返回 nil，把校验机会留给后续命令本身。
+func requireHTTPSIfHasCredentials(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return nil
+	}
+	if u.Scheme != "https" {
+		return &InvalidArgumentError{Msg: "Only https Git URLs support inline username/password credentials."}
+	}
+	return nil
+}
+
 // authFailureSnippets 是常见的 git 认证失败关键字（小写匹配）。
 //
 // 这里只放与"凭证"语义强相关的关键字，避免把通用的 "permission denied"

--- a/sandbox/git_auth.go
+++ b/sandbox/git_auth.go
@@ -11,19 +11,29 @@ import (
 type GitAuthError struct {
 	// Msg 是错误消息。
 	Msg string
+	// Err 是底层原始错误（可能是 errors.Join 聚合后的多个错误），用于 errors.Is/As 解包。
+	Err error
 }
 
 // Error 实现 error 接口。
 func (e *GitAuthError) Error() string { return e.Msg }
 
+// Unwrap 返回底层原始错误，方便调用方使用 errors.Is/As 进一步排查。
+func (e *GitAuthError) Unwrap() error { return e.Err }
+
 // GitUpstreamError 表示 git 操作因缺少 upstream 跟踪分支而中断。
 type GitUpstreamError struct {
 	// Msg 是错误消息。
 	Msg string
+	// Err 是底层原始错误（可能是 errors.Join 聚合后的多个错误），用于 errors.Is/As 解包。
+	Err error
 }
 
 // Error 实现 error 接口。
 func (e *GitUpstreamError) Error() string { return e.Msg }
+
+// Unwrap 返回底层原始错误，方便调用方使用 errors.Is/As 进一步排查。
+func (e *GitUpstreamError) Unwrap() error { return e.Err }
 
 // InvalidArgumentError 表示传入的参数非法。
 type InvalidArgumentError struct {

--- a/sandbox/git_integration_test.go
+++ b/sandbox/git_integration_test.go
@@ -349,10 +349,9 @@ func TestIntegrationGitRemoteAndPushPull(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, bare, url)
 
-	// Push 不给 Remote 但给 Branch → InvalidArgumentError
+	// Push 不给 Remote 但给 Branch：单 remote 仓库下应自动选中 origin 推送成功
 	_, err = e.git.Push(e.ctx, repo, &PushOptions{Branch: "main"})
-	var ie *InvalidArgumentError
-	assert.True(t, errors.As(err, &ie))
+	require.NoError(t, err, "Push 应能在单 remote 仓库下自动选中 origin")
 
 	// Push 显式 SetUpstream=false（不写 upstream）
 	noUpstream := false
@@ -377,9 +376,9 @@ func TestIntegrationGitRemoteAndPushPull(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	// Pull Branch 不给 Remote → InvalidArgumentError
+	// Pull 不给 Remote 但给 Branch：单 remote 仓库下应自动选中 origin 拉取成功
 	_, err = e.git.Pull(e.ctx, consumer, &PullOptions{Branch: "main"})
-	assert.True(t, errors.As(err, &ie))
+	require.NoError(t, err, "Pull 应能在单 remote 仓库下自动选中 origin")
 }
 
 // TestIntegrationGitPullMissingUpstream 覆盖 Pull 在没有 upstream 的本地分支上抛出 GitUpstreamError。

--- a/sandbox/git_integration_test.go
+++ b/sandbox/git_integration_test.go
@@ -1,0 +1,604 @@
+//go:build integration
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitTestEnv 把一次 git 集成测试常用的对象打包在一起，避免每个用例重复创建沙箱。
+type gitTestEnv struct {
+	t   *testing.T
+	sb  *Sandbox
+	git *Git
+	ctx context.Context
+}
+
+// newGitTestEnv 创建一个就绪的沙箱并在测试结束时清理。
+func newGitTestEnv(t *testing.T) *gitTestEnv {
+	t.Helper()
+	c := testClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	t.Cleanup(cancel)
+	sb := createTestSandbox(t, c, ctx)
+	return &gitTestEnv{t: t, sb: sb, git: sb.Git(), ctx: ctx}
+}
+
+// initRepo 在沙箱内初始化一个普通仓库并配置作者。
+func (e *gitTestEnv) initRepo(path, branch string) {
+	e.t.Helper()
+	_, err := e.git.Init(e.ctx, path, &InitOptions{InitialBranch: branch})
+	require.NoError(e.t, err, "Init %s", path)
+	_, err = e.git.ConfigureUser(e.ctx, "Tester", "tester@example.com", &ConfigOptions{
+		Scope: GitConfigScopeLocal,
+		Path:  path,
+	})
+	require.NoError(e.t, err, "ConfigureUser")
+}
+
+// writeAndCommit 写入一个文件并完成一次提交。
+func (e *gitTestEnv) writeAndCommit(repo, file, content, msg string) {
+	e.t.Helper()
+	_, err := e.sb.Files().Write(e.ctx, repo+"/"+file, []byte(content))
+	require.NoError(e.t, err, "Write %s", file)
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(e.t, err, "Add")
+	_, err = e.git.Commit(e.ctx, repo, msg, nil)
+	require.NoError(e.t, err, "Commit")
+}
+
+// TestIntegrationGitInitConfigureBranches 覆盖 Init / ConfigureUser / SetConfig / GetConfig /
+// Branches（含 unborn 仓库）/ CreateBranch / CheckoutBranch / DeleteBranch 的真实行为。
+func TestIntegrationGitInitConfigureBranches(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	repo := "/tmp/it-init"
+	_, err := e.git.Init(e.ctx, repo, &InitOptions{InitialBranch: "main"})
+	require.NoError(t, err)
+
+	// unborn 仓库 Branches() 应通过 symbolic-ref fallback 返回 "main"
+	br, err := e.git.Branches(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.Empty(t, br.Branches, "unborn 仓库不应有可枚举分支")
+	assert.Equal(t, "main", br.CurrentBranch, "unborn 仓库 fallback 后应得到 main")
+
+	_, err = e.git.ConfigureUser(e.ctx, "Alice", "a@x.io", &ConfigOptions{
+		Scope: GitConfigScopeLocal, Path: repo,
+	})
+	require.NoError(t, err)
+	val, err := e.git.GetConfig(e.ctx, "user.name", &ConfigOptions{Scope: GitConfigScopeLocal, Path: repo})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", val)
+
+	// 不存在的 key 必须返回空字符串、无错误
+	val, err = e.git.GetConfig(e.ctx, "user.notexist", &ConfigOptions{Scope: GitConfigScopeLocal, Path: repo})
+	require.NoError(t, err)
+	assert.Empty(t, val)
+
+	// SetConfig 任意 key
+	_, err = e.git.SetConfig(e.ctx, "core.autocrlf", "input", &ConfigOptions{Scope: GitConfigScopeLocal, Path: repo})
+	require.NoError(t, err)
+	val, err = e.git.GetConfig(e.ctx, "core.autocrlf", &ConfigOptions{Scope: GitConfigScopeLocal, Path: repo})
+	require.NoError(t, err)
+	assert.Equal(t, "input", val)
+
+	// Local scope 不给 Path 应直接报错
+	_, err = e.git.SetConfig(e.ctx, "k", "v", &ConfigOptions{Scope: GitConfigScopeLocal})
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie), "Local scope 缺 Path 应返回 InvalidArgumentError")
+
+	// 创建第一次提交后再做分支操作
+	e.writeAndCommit(repo, "README.md", "# init\n", "feat: init")
+
+	_, err = e.git.CreateBranch(e.ctx, repo, "feature/x", nil)
+	require.NoError(t, err)
+	br, err = e.git.Branches(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"main", "feature/x"}, br.Branches)
+	assert.Equal(t, "feature/x", br.CurrentBranch)
+
+	_, err = e.git.CheckoutBranch(e.ctx, repo, "main", nil)
+	require.NoError(t, err)
+	_, err = e.git.DeleteBranch(e.ctx, repo, "feature/x", &DeleteBranchOptions{Force: true})
+	require.NoError(t, err)
+
+	br, err = e.git.Branches(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"main"}, br.Branches)
+	assert.Equal(t, "main", br.CurrentBranch)
+
+	// 空分支名应被参数校验拦下
+	_, err = e.git.CreateBranch(e.ctx, repo, "", nil)
+	assert.True(t, errors.As(err, &ie))
+}
+
+// TestIntegrationGitAddOptions 覆盖 AddOptions.All 的三种取值（nil 默认 -A、显式 false 用 "."、Files 列表）。
+func TestIntegrationGitAddOptions(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	repo := "/tmp/it-add"
+	e.initRepo(repo, "main")
+	e.writeAndCommit(repo, "seed", "seed\n", "seed")
+
+	// 子目录 + 顶层各放一个新文件
+	_, err := e.sb.Files().Write(e.ctx, repo+"/top.txt", []byte("top\n"))
+	require.NoError(t, err)
+	_, err = e.sb.Files().Write(e.ctx, repo+"/sub/inner.txt", []byte("inner\n"))
+	require.NoError(t, err)
+
+	// 1) 显式 All=false：相当于 git add . —— 仓库根目录下应递归到子目录（git 行为）。
+	//    我们这里只验证不报错且 Status 至少认到一个 staged。
+	allFalse := false
+	_, err = e.git.Add(e.ctx, repo, &AddOptions{All: &allFalse})
+	require.NoError(t, err)
+	st, err := e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, st.StagedCount(), 1)
+
+	// 2) Files=[]：仅暂存指定文件
+	_, err = e.git.Reset(e.ctx, repo, &ResetOptions{Paths: []string{"."}})
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, repo, &AddOptions{Files: []string{"top.txt"}})
+	require.NoError(t, err)
+	st, err = e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	staged := stagedNames(st)
+	assert.Contains(t, staged, "top.txt")
+	assert.NotContains(t, staged, "sub/inner.txt")
+
+	// 3) opts=nil：默认 -A，应把所有未跟踪文件 stage 进来
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(t, err)
+	st, err = e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	staged = stagedNames(st)
+	assert.Contains(t, staged, "top.txt")
+	assert.Contains(t, staged, "sub/inner.txt")
+}
+
+// TestIntegrationGitStatusEdgeCases 验证 parseGitStatus 在真实输出下的健壮性：
+// detached HEAD、含空格的文件名、MM（同时 staged + unstaged）、unborn 仓库。
+func TestIntegrationGitStatusEdgeCases(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	repo := "/tmp/it-status"
+	e.initRepo(repo, "main")
+
+	// unborn：应能解析出 CurrentBranch=main 且 Detached=false
+	st, err := e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.False(t, st.Detached)
+	assert.Equal(t, "main", st.CurrentBranch)
+
+	e.writeAndCommit(repo, "README.md", "# v1\n", "feat: init")
+
+	// MM：同一文件 staged + 工作区再改一次
+	_, err = e.sb.Files().Write(e.ctx, repo+"/README.md", []byte("# v2\n"))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(t, err)
+	_, err = e.sb.Files().Write(e.ctx, repo+"/README.md", []byte("# v2 dirty\n"))
+	require.NoError(t, err)
+
+	// 含空格文件名（未跟踪）
+	_, err = e.sb.Files().Write(e.ctx, repo+"/with space.txt", []byte("x\n"))
+	require.NoError(t, err)
+
+	st, err = e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, st.StagedCount(), 1, "README.md 应同时计入 staged")
+	assert.GreaterOrEqual(t, st.UnstagedCount(), 1, "README.md 工作区改动应计入 unstaged")
+	assert.True(t, st.HasUntracked())
+
+	byName := map[string]GitFileStatus{}
+	for _, f := range st.FileStatus {
+		byName[f.Name] = f
+	}
+	assert.Contains(t, byName, "with space.txt", "含空格的文件名应被正确反引号解析")
+	if rm, ok := byName["README.md"]; ok {
+		assert.True(t, rm.Staged, "README.md 应有 staged 标记")
+	}
+
+	// detached HEAD
+	res, err := e.sb.Commands().Run(e.ctx, "git -C "+repo+" rev-parse HEAD",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	sha := strings.TrimSpace(res.Stdout)
+	require.NotEmpty(t, sha)
+	_, err = e.sb.Commands().Run(e.ctx, "git -C "+repo+" checkout "+sha,
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	st, err = e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.True(t, st.Detached, "checkout <sha> 后应进入 detached HEAD")
+	assert.Empty(t, st.CurrentBranch)
+}
+
+// TestIntegrationGitResetRestore 覆盖 Reset 各种 mode、Restore --staged 与 --source HEAD，以及无效参数组合。
+func TestIntegrationGitResetRestore(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	repo := "/tmp/it-reset"
+	e.initRepo(repo, "main")
+	e.writeAndCommit(repo, "a.txt", "v1\n", "init")
+
+	// --hard：丢弃工作区改动
+	_, err := e.sb.Files().Write(e.ctx, repo+"/a.txt", []byte("dirty\n"))
+	require.NoError(t, err)
+	_, err = e.git.Reset(e.ctx, repo, &ResetOptions{Mode: GitResetModeHard, Target: "HEAD"})
+	require.NoError(t, err)
+	got, err := e.sb.Files().ReadText(e.ctx, repo+"/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "v1\n", got)
+
+	// paths-only：unstage
+	_, err = e.sb.Files().Write(e.ctx, repo+"/a.txt", []byte("staged\n"))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(t, err)
+	_, err = e.git.Reset(e.ctx, repo, &ResetOptions{Paths: []string{"a.txt"}})
+	require.NoError(t, err)
+	st, err := e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, st.StagedCount())
+
+	// Mode + Paths 同时给 → InvalidArgumentError
+	_, err = e.git.Reset(e.ctx, repo, &ResetOptions{Mode: GitResetModeHard, Paths: []string{"a.txt"}})
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
+
+	// 非法 mode → InvalidArgumentError
+	_, err = e.git.Reset(e.ctx, repo, &ResetOptions{Mode: GitResetMode("bogus")})
+	assert.True(t, errors.As(err, &ie))
+
+	// Restore --staged：仅取消暂存，工作区保留
+	_, err = e.sb.Files().Write(e.ctx, repo+"/a.txt", []byte("again\n"))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(t, err)
+	staged := true
+	_, err = e.git.Restore(e.ctx, repo, &RestoreOptions{Paths: []string{"a.txt"}, Staged: &staged})
+	require.NoError(t, err)
+	got, err = e.sb.Files().ReadText(e.ctx, repo+"/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "again\n", got, "Restore --staged 不应改动工作区")
+	st, err = e.git.Status(e.ctx, repo, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, st.StagedCount())
+
+	// Restore --source HEAD：把工作区恢复回 HEAD
+	_, err = e.git.Restore(e.ctx, repo, &RestoreOptions{Paths: []string{"a.txt"}, Source: "HEAD"})
+	require.NoError(t, err)
+	got, err = e.sb.Files().ReadText(e.ctx, repo+"/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "v1\n", got)
+
+	// Restore Paths 为空 → 错
+	_, err = e.git.Restore(e.ctx, repo, &RestoreOptions{})
+	assert.Error(t, err)
+}
+
+// TestIntegrationGitCommitOptions 覆盖 CommitOptions 的 Author 覆盖与 AllowEmpty。
+func TestIntegrationGitCommitOptions(t *testing.T) {
+	e := newGitTestEnv(t)
+	repo := "/tmp/it-commit"
+	e.initRepo(repo, "main")
+	e.writeAndCommit(repo, "seed", "seed\n", "seed")
+
+	// 空消息 → 拒绝
+	_, err := e.git.Commit(e.ctx, repo, "", nil)
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
+
+	// Author 覆盖
+	_, err = e.sb.Files().Write(e.ctx, repo+"/b.txt", []byte("b\n"))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, repo, nil)
+	require.NoError(t, err)
+	_, err = e.git.Commit(e.ctx, repo, "feat: b", &CommitOptions{
+		AuthorName: "Bob", AuthorEmail: "bob@x.io",
+	})
+	require.NoError(t, err)
+	res, err := e.sb.Commands().Run(e.ctx, "git -C "+repo+" log -1 --pretty=%an",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", strings.TrimSpace(res.Stdout))
+
+	// AllowEmpty=true：在 clean 工作区上仍能提交
+	_, err = e.git.Commit(e.ctx, repo, "chore: empty", &CommitOptions{AllowEmpty: true})
+	require.NoError(t, err)
+
+	// AllowEmpty=false（默认）：clean 工作区会失败
+	_, err = e.git.Commit(e.ctx, repo, "chore: should fail", nil)
+	assert.Error(t, err)
+}
+
+// TestIntegrationGitRemoteAndPushPull 覆盖 RemoteAdd（含 Overwrite）/ RemoteGet（缺失）/
+// Push（SetUpstream 默认 true 与显式 false） / Pull / 参数校验。
+func TestIntegrationGitRemoteAndPushPull(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	repo := "/tmp/it-remote"
+	bare := "/tmp/it-remote.git"
+	consumer := "/tmp/it-consumer"
+	e.initRepo(repo, "main")
+	e.writeAndCommit(repo, "README.md", "# v1\n", "init")
+	_, err := e.git.Init(e.ctx, bare, &InitOptions{Bare: true, InitialBranch: "main"})
+	require.NoError(t, err)
+
+	// RemoteGet 不存在 → 空字符串、无错
+	url, err := e.git.RemoteGet(e.ctx, repo, "nope", nil)
+	require.NoError(t, err)
+	assert.Empty(t, url)
+
+	// RemoteAdd 占位 URL，再 Overwrite 改成 bare 路径
+	_, err = e.git.RemoteAdd(e.ctx, repo, "origin", "https://example.com/x.git", nil)
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, repo, "origin", bare, &RemoteAddOptions{Overwrite: true})
+	require.NoError(t, err)
+	url, err = e.git.RemoteGet(e.ctx, repo, "origin", nil)
+	require.NoError(t, err)
+	assert.Equal(t, bare, url)
+
+	// Push 不给 Remote 但给 Branch → InvalidArgumentError
+	_, err = e.git.Push(e.ctx, repo, &PushOptions{Branch: "main"})
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
+
+	// Push 显式 SetUpstream=false（不写 upstream）
+	noUpstream := false
+	_, err = e.git.Push(e.ctx, repo, &PushOptions{
+		Remote: "origin", Branch: "main", SetUpstream: &noUpstream,
+	})
+	require.NoError(t, err)
+
+	// Clone 出 consumer 仓库
+	_, err = e.git.Clone(e.ctx, bare, &CloneOptions{Path: consumer})
+	require.NoError(t, err)
+
+	// 主仓再 push 一次（这次走 SetUpstream 默认 true）
+	e.writeAndCommit(repo, "CHANGELOG.md", "v1\n", "docs")
+	_, err = e.git.Push(e.ctx, repo, &PushOptions{Remote: "origin", Branch: "main"})
+	require.NoError(t, err)
+
+	// consumer Pull —— 不给 Branch 也不给 Remote，应通过 hasUpstream 走默认路径
+	_, err = e.git.Pull(e.ctx, consumer, &PullOptions{})
+	require.NoError(t, err)
+	exists, err := e.sb.Files().Exists(e.ctx, consumer+"/CHANGELOG.md")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Pull Branch 不给 Remote → InvalidArgumentError
+	_, err = e.git.Pull(e.ctx, consumer, &PullOptions{Branch: "main"})
+	assert.True(t, errors.As(err, &ie))
+}
+
+// TestIntegrationGitPullMissingUpstream 覆盖 Pull 在没有 upstream 的本地分支上抛出 GitUpstreamError。
+func TestIntegrationGitPullMissingUpstream(t *testing.T) {
+	e := newGitTestEnv(t)
+	repo := "/tmp/it-no-upstream"
+	e.initRepo(repo, "main")
+	e.writeAndCommit(repo, "a", "a\n", "init")
+
+	_, err := e.git.Pull(e.ctx, repo, &PullOptions{})
+	var ue *GitUpstreamError
+	assert.True(t, errors.As(err, &ue), "缺 upstream 时 Pull 应返回 GitUpstreamError，实际: %T %v", err, err)
+}
+
+// TestIntegrationGitDangerouslyAuthenticate 验证凭证确实被 git credential helper 持久化。
+func TestIntegrationGitDangerouslyAuthenticate(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	// Protocol 非 https → InvalidArgumentError
+	_, err := e.git.DangerouslyAuthenticate(e.ctx, &AuthenticateOptions{
+		Username: "u", Password: "p", Host: "h", Protocol: "ssh",
+	})
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
+
+	// 写入凭证（仅在沙箱内）
+	_, err = e.git.DangerouslyAuthenticate(e.ctx, &AuthenticateOptions{
+		Username: "demo-user", Password: "demo-token", Host: "fake-host.example",
+	})
+	require.NoError(t, err)
+
+	// 用 `git credential fill` 验证：输入 protocol/host，git 会从 store 中回填 username/password
+	input := "protocol=https\nhost=fake-host.example\n\n"
+	res, err := e.sb.Commands().Run(e.ctx,
+		"printf %s '"+input+"' | git credential fill",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.ExitCode, "credential fill 应成功，stdout=%q stderr=%q", res.Stdout, res.Stderr)
+	assert.Contains(t, res.Stdout, "username=demo-user")
+	assert.Contains(t, res.Stdout, "password=demo-token")
+}
+
+// TestIntegrationGitCloneStripsCredentials 验证默认情况下 clone 完成后 origin URL 不再带凭证。
+// 仅当提供 QINIU_GIT_REPO_URL/USERNAME/PASSWORD 时执行。
+func TestIntegrationGitCloneStripsCredentials(t *testing.T) {
+	repoURL, username, password := getGitCredsFromEnv(t)
+	e := newGitTestEnv(t)
+
+	clonePath := "/tmp/it-clone-strip"
+	_, err := e.git.Clone(e.ctx, repoURL, &CloneOptions{
+		Path: clonePath, Depth: 1, Username: username, Password: password,
+	})
+	require.NoError(t, err)
+	got, err := e.git.RemoteGet(e.ctx, clonePath, "origin", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, got, username+":", "默认应剥离 origin URL 中的凭证")
+	assert.NotContains(t, got, password)
+}
+
+// TestIntegrationGitCloneBranch 用沙箱内自建 bare repo 模拟一个多分支 remote，
+// 验证 CloneOptions.Branch 能让 HEAD 指向指定分支，并且默认情况下 origin URL 不残留凭证。
+func TestIntegrationGitCloneBranch(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	source := "/tmp/it-clone-src"
+	bare := "/tmp/it-clone-src.git"
+	dst := "/tmp/it-clone-dst"
+
+	e.initRepo(source, "main")
+	e.writeAndCommit(source, "main.txt", "main\n", "feat: main")
+
+	// 在 source 上再造一个 release 分支并提交
+	_, err := e.git.CreateBranch(e.ctx, source, "release", nil)
+	require.NoError(t, err)
+	e.writeAndCommit(source, "release.txt", "release\n", "feat: release")
+	_, err = e.git.CheckoutBranch(e.ctx, source, "main", nil)
+	require.NoError(t, err)
+
+	// 把 source push 到 bare 当作"远端"
+	_, err = e.git.Init(e.ctx, bare, &InitOptions{Bare: true, InitialBranch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, source, "origin", bare, nil)
+	require.NoError(t, err)
+	_, err = e.git.Push(e.ctx, source, &PushOptions{Remote: "origin", Branch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.Push(e.ctx, source, &PushOptions{Remote: "origin", Branch: "release"})
+	require.NoError(t, err)
+
+	// 走 CloneOptions.Branch 拉取 release
+	_, err = e.git.Clone(e.ctx, bare, &CloneOptions{Path: dst, Branch: "release"})
+	require.NoError(t, err)
+
+	// HEAD 应指向 release
+	br, err := e.git.Branches(e.ctx, dst, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "release", br.CurrentBranch)
+	exists, err := e.sb.Files().Exists(e.ctx, dst+"/release.txt")
+	require.NoError(t, err)
+	assert.True(t, exists, "Branch=release 时 release.txt 应存在")
+
+	// origin URL 不应包含任何 user info（无凭证残留）
+	origin, err := e.git.RemoteGet(e.ctx, dst, "origin", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, origin, "@")
+}
+
+// TestIntegrationGitRemoteAddFetch 验证 RemoteAddOptions.Fetch=true 在添加 remote
+// 后立即拉取引用，使 origin/<branch> 可被 rev-parse 解析。
+func TestIntegrationGitRemoteAddFetch(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	source := "/tmp/it-fetch-src"
+	bare := "/tmp/it-fetch-src.git"
+	consumer := "/tmp/it-fetch-consumer"
+
+	e.initRepo(source, "main")
+	e.writeAndCommit(source, "a.txt", "a\n", "init")
+	_, err := e.git.Init(e.ctx, bare, &InitOptions{Bare: true, InitialBranch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, source, "origin", bare, nil)
+	require.NoError(t, err)
+	_, err = e.git.Push(e.ctx, source, &PushOptions{Remote: "origin", Branch: "main"})
+	require.NoError(t, err)
+
+	// consumer：先 init 再 RemoteAdd（Fetch=false） → 不应能解析 origin/main
+	_, err = e.git.Init(e.ctx, consumer, &InitOptions{InitialBranch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, consumer, "origin", bare, nil)
+	require.NoError(t, err)
+
+	res, err := e.sb.Commands().Run(e.ctx, "git -C "+consumer+" rev-parse --verify -q origin/main",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, res.ExitCode, "Fetch=false 时 origin/main 不应可解析")
+
+	// 用 Overwrite=true + Fetch=true 重新加一次（同一个 origin）
+	_, err = e.git.RemoteAdd(e.ctx, consumer, "origin", bare, &RemoteAddOptions{
+		Overwrite: true, Fetch: true,
+	})
+	require.NoError(t, err)
+
+	res, err = e.sb.Commands().Run(e.ctx, "git -C "+consumer+" rev-parse --verify -q origin/main",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.ExitCode, "Fetch=true 时 origin/main 应已被拉取，stderr=%q", res.Stderr)
+	assert.NotEmpty(t, strings.TrimSpace(res.Stdout))
+}
+
+// TestIntegrationGitOptionsEnvsCwdTimeout 验证 GitOptions.Envs / Cwd / Timeout 的真实生效路径：
+//   - Envs：自定义 GIT_AUTHOR_DATE 应作用到 commit；同时 GIT_TERMINAL_PROMPT=0 不会被调用方覆盖。
+//   - Cwd：在 cwd 下用相对路径 Init 应在 cwd 内建出仓库。
+//   - Timeout：极短超时应让命令失败而非挂住。
+func TestIntegrationGitOptionsEnvsCwdTimeout(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	// --- Envs ---
+	envRepo := "/tmp/it-envs"
+	e.initRepo(envRepo, "main")
+	_, err := e.sb.Files().Write(e.ctx, envRepo+"/a.txt", []byte("a\n"))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, envRepo, nil)
+	require.NoError(t, err)
+
+	authorDate := "2020-01-02T03:04:05+00:00"
+	// 故意把 GIT_TERMINAL_PROMPT 置为 "1"，验证 SDK 默认值会被写在最后从而覆盖回 "0"。
+	_, err = e.git.Commit(e.ctx, envRepo, "feat: dated", &CommitOptions{
+		GitOptions: GitOptions{
+			Envs: map[string]string{
+				"GIT_AUTHOR_DATE":     authorDate,
+				"GIT_COMMITTER_DATE":  authorDate,
+				"GIT_TERMINAL_PROMPT": "1", // 不应生效，SDK 必须强制 0
+			},
+		},
+	})
+	require.NoError(t, err)
+	res, err := e.sb.Commands().Run(e.ctx, "git -C "+envRepo+" log -1 --pretty=%aI",
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	assert.Equal(t, "2020-01-02T03:04:05+00:00", strings.TrimSpace(res.Stdout))
+
+	// --- Cwd ---
+	cwdParent := "/tmp/it-cwd"
+	_, err = e.sb.Commands().Run(e.ctx, "mkdir -p "+cwdParent,
+		WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+	require.NoError(t, err)
+	_, err = e.git.Init(e.ctx, "nested", &InitOptions{
+		InitialBranch: "main",
+		GitOptions:    GitOptions{Cwd: cwdParent},
+	})
+	require.NoError(t, err)
+	exists, err := e.sb.Files().Exists(e.ctx, cwdParent+"/nested/.git/HEAD")
+	require.NoError(t, err)
+	assert.True(t, exists, "Cwd 下相对路径 Init 应在 %s/nested 建出仓库", cwdParent)
+
+	// --- Timeout ---
+	// 极短超时下任何 git 命令都应直接失败/超时，而不是挂住。
+	_, err = e.git.Status(e.ctx, envRepo, &GitOptions{Timeout: 1 * time.Nanosecond})
+	assert.Error(t, err, "Timeout=1ns 应导致命令失败")
+}
+
+// stagedNames 返回 status 中处于 staged 状态的文件名集合。
+func stagedNames(s *GitStatus) []string {
+	var out []string
+	for _, f := range s.FileStatus {
+		if f.Staged {
+			out = append(out, f.Name)
+		}
+	}
+	return out
+}
+
+// getGitCredsFromEnv 从环境变量读取 git 凭证；缺失时跳过当前测试。
+func getGitCredsFromEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+	repoURL := strings.TrimSpace(os.Getenv("QINIU_GIT_REPO_URL"))
+	username := strings.TrimSpace(os.Getenv("QINIU_GIT_USERNAME"))
+	password := strings.TrimSpace(os.Getenv("QINIU_GIT_PASSWORD"))
+	if repoURL == "" || username == "" || password == "" {
+		t.Skip("未设置 QINIU_GIT_REPO_URL / QINIU_GIT_USERNAME / QINIU_GIT_PASSWORD，跳过带凭证的 Clone 测试")
+	}
+	return repoURL, username, password
+}

--- a/sandbox/git_integration_test.go
+++ b/sandbox/git_integration_test.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -578,6 +579,124 @@ func TestIntegrationGitOptionsEnvsCwdTimeout(t *testing.T) {
 	// 极短超时下任何 git 命令都应直接失败/超时，而不是挂住。
 	_, err = e.git.Status(e.ctx, envRepo, &GitOptions{Timeout: 1 * time.Nanosecond})
 	assert.Error(t, err, "Timeout=1ns 应导致命令失败")
+}
+
+// TestIntegrationGitPushPullWithCredentials 端到端验证带凭证的 Clone → Commit → Push → Pull
+// 完整走通真实远端：
+//  1. Clone 仓库到沙箱（带凭证、默认剥离）
+//  2. 创建一个唯一分支（it-push-<timestamp>-<pid>）
+//  3. 写文件 + commit + Push（SetUpstream=true）到远端
+//  4. Re-clone 一份新仓库 + Pull 该分支，验证文件可见
+//  5. t.Cleanup 通过 push --delete 清理远端分支
+//
+// 仅当 QINIU_GIT_REPO_URL/USERNAME/PASSWORD 都配置了写权限时才执行。
+// 请确保使用专用的"测试仓库"，不要指向业务仓库。
+func TestIntegrationGitPushPullWithCredentials(t *testing.T) {
+	repoURL, username, password := getGitCredsFromEnv(t)
+	e := newGitTestEnv(t)
+
+	branch := fmt.Sprintf("it-push-%d-%d", time.Now().UnixNano(), os.Getpid())
+	work := "/tmp/it-rpush-work"
+	verify := "/tmp/it-rpush-verify"
+	marker := fmt.Sprintf("sandbox integration test %s\n", branch)
+	markerFile := branch + ".txt"
+
+	// 1) Clone 工作仓库（带凭证；默认剥离）
+	_, err := e.git.Clone(e.ctx, repoURL, &CloneOptions{
+		Path: work, Depth: 1, Username: username, Password: password,
+	})
+	require.NoError(t, err)
+
+	originURL, err := e.git.RemoteGet(e.ctx, work, "origin", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, originURL, username+":", "clone 后 origin URL 不应残留凭证")
+
+	// 2) 配置 author，避免依赖远端默认配置
+	_, err = e.git.ConfigureUser(e.ctx, "Sandbox Integration", "sandbox-it@example.com",
+		&ConfigOptions{Scope: GitConfigScopeLocal, Path: work})
+	require.NoError(t, err)
+
+	// 3) 在唯一分支上 commit + push
+	_, err = e.git.CreateBranch(e.ctx, work, branch, nil)
+	require.NoError(t, err)
+	_, err = e.sb.Files().Write(e.ctx, work+"/"+markerFile, []byte(marker))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, work, nil)
+	require.NoError(t, err)
+	_, err = e.git.Commit(e.ctx, work, "test: sandbox integration "+branch, nil)
+	require.NoError(t, err)
+
+	// 4) cleanup：无论后面成功失败都尝试删除远端分支
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		// 用 shell 直接 push --delete，避免再走一遍 SDK 的凭证注入路径
+		authedURL, werr := withCredentials(repoURL, username, password)
+		if werr != nil {
+			t.Logf("cleanup withCredentials 失败: %v", werr)
+			return
+		}
+		cmd := fmt.Sprintf("git -C %s push %s --delete %s",
+			shellEscape(work), shellEscape(authedURL), shellEscape(branch))
+		res, err := e.sb.Commands().Run(cleanupCtx, cmd,
+			WithEnvs(map[string]string{"GIT_TERMINAL_PROMPT": "0"}))
+		if err != nil || (res != nil && res.ExitCode != 0) {
+			t.Logf("cleanup 删除远端分支 %s 失败（可能仓库已无该分支）: err=%v exit=%v stderr=%q",
+				branch, err, res.ExitCode, res.Stderr)
+		} else {
+			t.Logf("已删除远端临时分支 %s", branch)
+		}
+	})
+
+	_, err = e.git.Push(e.ctx, work, &PushOptions{
+		Remote: "origin", Branch: branch,
+		Username: username, Password: password,
+	})
+	require.NoError(t, err, "Push 失败 —— 请确认 token 具备目标仓库的 push 权限")
+
+	// Push 之后 origin URL 仍不应包含凭证
+	originURL, err = e.git.RemoteGet(e.ctx, work, "origin", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, originURL, username+":", "Push 完成后 origin URL 不应残留凭证")
+	assert.NotContains(t, originURL, password)
+
+	// 5) 用一个全新的仓库 Clone + Pull，验证 push 上去的提交真的可被远端读到
+	_, err = e.git.Clone(e.ctx, repoURL, &CloneOptions{
+		Path: verify, Branch: branch, Depth: 1,
+		Username: username, Password: password,
+	})
+	require.NoError(t, err, "Clone --branch %s 失败 —— Push 可能没真正生效", branch)
+
+	exists, err := e.sb.Files().Exists(e.ctx, verify+"/"+markerFile)
+	require.NoError(t, err)
+	assert.True(t, exists, "新 clone 出来的仓库应能看到 push 上去的 %s", markerFile)
+	got, err := e.sb.Files().ReadText(e.ctx, verify+"/"+markerFile)
+	require.NoError(t, err)
+	assert.Equal(t, marker, got)
+
+	// 6) 在 work 上再追加一次提交并 push，然后在 verify 仓库 Pull，验证 Pull 拉到新提交
+	follow := "follow-up\n"
+	followFile := branch + "-2.txt"
+	_, err = e.sb.Files().Write(e.ctx, work+"/"+followFile, []byte(follow))
+	require.NoError(t, err)
+	_, err = e.git.Add(e.ctx, work, nil)
+	require.NoError(t, err)
+	_, err = e.git.Commit(e.ctx, work, "test: follow-up "+branch, nil)
+	require.NoError(t, err)
+	_, err = e.git.Push(e.ctx, work, &PushOptions{
+		Remote: "origin", Branch: branch,
+		Username: username, Password: password,
+	})
+	require.NoError(t, err)
+
+	_, err = e.git.Pull(e.ctx, verify, &PullOptions{
+		Remote: "origin", Branch: branch,
+		Username: username, Password: password,
+	})
+	require.NoError(t, err)
+	exists, err = e.sb.Files().Exists(e.ctx, verify+"/"+followFile)
+	require.NoError(t, err)
+	assert.True(t, exists, "Pull 之后应能看到 follow-up 文件 %s", followFile)
 }
 
 // stagedNames 返回 status 中处于 staged 状态的文件名集合。

--- a/sandbox/git_integration_test.go
+++ b/sandbox/git_integration_test.go
@@ -393,6 +393,52 @@ func TestIntegrationGitPullMissingUpstream(t *testing.T) {
 	assert.True(t, errors.As(err, &ue), "缺 upstream 时 Pull 应返回 GitUpstreamError，实际: %T %v", err, err)
 }
 
+// TestIntegrationGitPushPullBranchWithoutRemote 覆盖在多 remote / 无 remote 仓库上
+// 仅指定 Branch 不指定 Remote 时，SDK 应返回 InvalidArgumentError 而不是把分支名当 remote 名传给 git。
+func TestIntegrationGitPushPullBranchWithoutRemote(t *testing.T) {
+	e := newGitTestEnv(t)
+
+	// 1) 无 remote 仓库
+	noRemote := "/tmp/it-no-remote"
+	e.initRepo(noRemote, "main")
+	e.writeAndCommit(noRemote, "a", "a\n", "init")
+
+	_, err := e.git.Push(e.ctx, noRemote, &PushOptions{Branch: "main"})
+	var ie1 *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie1), "无 remote 时 Push(Branch:main) 应返回 InvalidArgumentError，实际: %T %v", err, err)
+
+	_, err = e.git.Pull(e.ctx, noRemote, &PullOptions{Branch: "main"})
+	var ie2 *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie2), "无 remote 时 Pull(Branch:main) 应返回 InvalidArgumentError，实际: %T %v", err, err)
+
+	// 2) 多 remote 仓库
+	multi := "/tmp/it-multi-remote"
+	e.initRepo(multi, "main")
+	e.writeAndCommit(multi, "a", "a\n", "init")
+	bare1 := "/tmp/it-multi-bare1.git"
+	bare2 := "/tmp/it-multi-bare2.git"
+	_, err = e.git.Init(e.ctx, bare1, &InitOptions{Bare: true, InitialBranch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.Init(e.ctx, bare2, &InitOptions{Bare: true, InitialBranch: "main"})
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, multi, "origin", bare1, nil)
+	require.NoError(t, err)
+	_, err = e.git.RemoteAdd(e.ctx, multi, "backup", bare2, nil)
+	require.NoError(t, err)
+
+	_, err = e.git.Push(e.ctx, multi, &PushOptions{Branch: "main"})
+	var ie3 *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie3), "多 remote 时 Push(Branch:main) 应返回 InvalidArgumentError，实际: %T %v", err, err)
+
+	_, err = e.git.Pull(e.ctx, multi, &PullOptions{Branch: "main"})
+	var ie4 *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie4), "多 remote 时 Pull(Branch:main) 应返回 InvalidArgumentError，实际: %T %v", err, err)
+
+	// 显式给 Remote 时仍可正常工作
+	_, err = e.git.Push(e.ctx, multi, &PushOptions{Remote: "origin", Branch: "main"})
+	require.NoError(t, err, "多 remote 仓库下显式 Remote 应能正常 Push")
+}
+
 // TestIntegrationGitDangerouslyAuthenticate 验证凭证确实被 git credential helper 持久化。
 func TestIntegrationGitDangerouslyAuthenticate(t *testing.T) {
 	e := newGitTestEnv(t)

--- a/sandbox/git_integration_test.go
+++ b/sandbox/git_integration_test.go
@@ -439,6 +439,25 @@ func TestIntegrationGitPushPullBranchWithoutRemote(t *testing.T) {
 	require.NoError(t, err, "多 remote 仓库下显式 Remote 应能正常 Push")
 }
 
+// TestIntegrationGitPushPullSurfacesRepoErrors 验证当 path 不是 git 仓库时，
+// Push/Pull 直接返回真实仓库错误，而不是被 autoSelectRemote 吞成 InvalidArgumentError。
+func TestIntegrationGitPushPullSurfacesRepoErrors(t *testing.T) {
+	e := newGitTestEnv(t)
+	notRepo := "/tmp/it-not-a-repo"
+	_, err := e.sb.Files().MakeDir(e.ctx, notRepo)
+	require.NoError(t, err)
+
+	_, err = e.git.Push(e.ctx, notRepo, &PushOptions{Branch: "main"})
+	require.Error(t, err)
+	var ie1 *InvalidArgumentError
+	assert.False(t, errors.As(err, &ie1), "非仓库目录的 Push 错误不应被掩盖成 InvalidArgumentError，实际: %T %v", err, err)
+
+	_, err = e.git.Pull(e.ctx, notRepo, &PullOptions{Branch: "main"})
+	require.Error(t, err)
+	var ie2 *InvalidArgumentError
+	assert.False(t, errors.As(err, &ie2), "非仓库目录的 Pull 错误不应被掩盖成 InvalidArgumentError，实际: %T %v", err, err)
+}
+
 // TestIntegrationGitDangerouslyAuthenticate 验证凭证确实被 git credential helper 持久化。
 func TestIntegrationGitDangerouslyAuthenticate(t *testing.T) {
 	e := newGitTestEnv(t)

--- a/sandbox/git_options.go
+++ b/sandbox/git_options.go
@@ -168,5 +168,6 @@ type AuthenticateOptions struct {
 	// Host 是要认证的主机，缺省为 "github.com"。
 	Host string
 	// Protocol 是要认证的协议，缺省为 "https"。
+	// 出于安全考虑只允许 "https"，传入其他值会返回 InvalidArgumentError。
 	Protocol string
 }

--- a/sandbox/git_options.go
+++ b/sandbox/git_options.go
@@ -1,0 +1,172 @@
+package sandbox
+
+import "time"
+
+// GitOptions 是 git 命令执行的通用选项，可以被各 Options Struct 嵌入复用。
+type GitOptions struct {
+	// Envs 是额外的环境变量。SDK 会自动注入 GIT_TERMINAL_PROMPT=0 以禁止交互式提示。
+	Envs map[string]string
+	// User 指定执行命令的用户，缺省使用 DefaultUser。
+	User string
+	// Cwd 指定工作目录。
+	Cwd string
+	// Timeout 指定命令超时时间。
+	Timeout time.Duration
+}
+
+// CloneOptions 是 git clone 操作的选项。
+type CloneOptions struct {
+	GitOptions
+	// Path 指定克隆目标路径。
+	Path string
+	// Branch 指定要检出的分支，设置后会附加 --single-branch。
+	Branch string
+	// Depth 指定浅克隆深度。
+	Depth int
+	// Username 是 HTTPS 认证的用户名。
+	Username string
+	// Password 是 HTTPS 认证的密码或 token。
+	Password string
+	// DangerouslyStoreCredentials 为 true 时，凭证会持久化在 .git/config 中；
+	// 默认会在 clone 完成后通过 remote set-url 清除。
+	DangerouslyStoreCredentials bool
+}
+
+// InitOptions 是 git init 操作的选项。
+type InitOptions struct {
+	GitOptions
+	// Bare 为 true 时创建 bare 仓库。
+	Bare bool
+	// InitialBranch 指定初始分支名（例如 "main"）。
+	InitialBranch string
+}
+
+// RemoteAddOptions 是 git remote add 操作的选项。
+type RemoteAddOptions struct {
+	GitOptions
+	// Fetch 为 true 时在添加 remote 后立即执行 fetch。
+	Fetch bool
+	// Overwrite 为 true 时，若 remote 已存在则覆盖其 URL。
+	Overwrite bool
+}
+
+// CommitOptions 是 git commit 操作的选项。
+type CommitOptions struct {
+	GitOptions
+	// AuthorName 覆盖提交作者名。
+	AuthorName string
+	// AuthorEmail 覆盖提交作者邮箱。
+	AuthorEmail string
+	// AllowEmpty 允许空提交。
+	AllowEmpty bool
+}
+
+// AddOptions 是 git add 操作的选项。
+type AddOptions struct {
+	GitOptions
+	// Files 指定要暂存的文件列表，为空时根据 All 决定使用 -A 或 "."。
+	Files []string
+	// All 控制 Files 为空时是否使用 -A 暂存所有变更。
+	// 为 nil 时默认 true（与 E2B 对齐）；显式为 false 则使用 "." 仅暂存当前目录。
+	All *bool
+}
+
+// DeleteBranchOptions 是 git branch -d/-D 操作的选项。
+type DeleteBranchOptions struct {
+	GitOptions
+	// Force 为 true 时使用 -D 强制删除分支。
+	Force bool
+}
+
+// GitResetMode 是 git reset 的模式。
+type GitResetMode string
+
+const (
+	// GitResetModeSoft 对应 git reset --soft。
+	GitResetModeSoft GitResetMode = "soft"
+	// GitResetModeMixed 对应 git reset --mixed。
+	GitResetModeMixed GitResetMode = "mixed"
+	// GitResetModeHard 对应 git reset --hard。
+	GitResetModeHard GitResetMode = "hard"
+	// GitResetModeMerge 对应 git reset --merge。
+	GitResetModeMerge GitResetMode = "merge"
+	// GitResetModeKeep 对应 git reset --keep。
+	GitResetModeKeep GitResetMode = "keep"
+)
+
+// ResetOptions 是 git reset 操作的选项。
+type ResetOptions struct {
+	GitOptions
+	// Mode 是重置模式，缺省时不传 --<mode> 参数。
+	Mode GitResetMode
+	// Target 是要重置到的提交、分支或引用，缺省为 HEAD。
+	Target string
+	// Paths 是要重置的路径列表。
+	Paths []string
+}
+
+// RestoreOptions 是 git restore 操作的选项。
+// 当 Staged 与 Worktree 均未显式设置时，默认仅恢复工作区（Worktree=true）。
+type RestoreOptions struct {
+	GitOptions
+	// Paths 是要恢复的路径列表，至少一个。
+	Paths []string
+	// Staged 为非 nil 时显式控制是否恢复索引。
+	Staged *bool
+	// Worktree 为非 nil 时显式控制是否恢复工作区。
+	Worktree *bool
+	// Source 指定从该提交或引用恢复。
+	Source string
+}
+
+// PushOptions 是 git push 操作的选项。
+type PushOptions struct {
+	GitOptions
+	// Remote 指定远程名（例如 "origin"）。
+	Remote string
+	// Branch 指定要推送的分支名。
+	Branch string
+	// SetUpstream 控制是否附加 --set-upstream。
+	// 为 nil 时按 SDK 默认（true，与 E2B 对齐）；显式设置为 false 可关闭。
+	SetUpstream *bool
+	// Username 是 HTTPS 认证的用户名。
+	Username string
+	// Password 是 HTTPS 认证的密码或 token。
+	Password string
+}
+
+// PullOptions 是 git pull 操作的选项。
+type PullOptions struct {
+	GitOptions
+	// Remote 指定远程名。
+	Remote string
+	// Branch 指定要拉取的分支名。
+	Branch string
+	// Username 是 HTTPS 认证的用户名。
+	Username string
+	// Password 是 HTTPS 认证的密码或 token。
+	Password string
+}
+
+// ConfigOptions 是 git config 操作的选项。
+// Scope 为 "local" 时必须提供 Path。
+type ConfigOptions struct {
+	GitOptions
+	// Scope 是 git config 作用域，缺省为 GitConfigScopeGlobal。
+	Scope GitConfigScope
+	// Path 是仓库路径，仅在 Scope 为 GitConfigScopeLocal 时必填。
+	Path string
+}
+
+// AuthenticateOptions 是 DangerouslyAuthenticate 的选项。
+type AuthenticateOptions struct {
+	GitOptions
+	// Username 是 HTTPS 认证的用户名，必填。
+	Username string
+	// Password 是 HTTPS 认证的密码或 token，必填。
+	Password string
+	// Host 是要认证的主机，缺省为 "github.com"。
+	Host string
+	// Protocol 是要认证的协议，缺省为 "https"。
+	Protocol string
+}

--- a/sandbox/git_parse.go
+++ b/sandbox/git_parse.go
@@ -1,0 +1,237 @@
+package sandbox
+
+import (
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// deriveRepoDirFromURL 从 git URL 推导默认的仓库目录名（去除 .git 后缀）。
+func deriveRepoDirFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	var name string
+	if err == nil && u.Path != "" {
+		name = path.Base(u.Path)
+	} else {
+		// 处理形如 git@host:owner/repo.git 的 SCP 风格地址。
+		if idx := strings.LastIndex(rawURL, ":"); idx >= 0 {
+			name = path.Base(rawURL[idx+1:])
+		} else {
+			name = path.Base(rawURL)
+		}
+	}
+	name = strings.TrimSuffix(name, ".git")
+	if name == "." || name == "/" || name == "" {
+		return ""
+	}
+	return name
+}
+
+// parseGitStatus 解析 `git status --porcelain=1 -b` 的输出。
+func parseGitStatus(out string) *GitStatus {
+	status := &GitStatus{}
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			parseBranchLine(line[3:], status)
+			continue
+		}
+		entry, ok := parseFileStatusLine(line)
+		if ok {
+			status.FileStatus = append(status.FileStatus, entry)
+		}
+	}
+	return status
+}
+
+// parseBranchLine 解析 porcelain 输出首行的分支信息。
+//
+// 需处理 git 在多种状态下的输出形态：
+//   - "main...origin/main [ahead 1, behind 2]" 普通跟踪分支
+//   - "HEAD (no branch)"                       传统 detached HEAD（如 rebase 中）
+//   - "HEAD (detached at <ref>)"               显式 detached HEAD
+//   - "No commits yet on main"                 unborn 分支（仓库未首次提交）
+//   - "Initial commit on main"                 旧版 git 的 unborn 写法
+//
+// 不能简单按第一个空格切分，否则 "No commits yet on main" 会把 "No" 当成分支名。
+func parseBranchLine(line string, status *GitStatus) {
+	if line == "" {
+		return
+	}
+
+	// 先剥离尾部的 "[ahead N, behind M]"
+	branchPart := line
+	rest := ""
+	if i := strings.Index(line, " ["); i >= 0 && strings.HasSuffix(line, "]") {
+		branchPart = line[:i]
+		rest = line[i+2 : len(line)-1]
+	}
+
+	// 处理 detached HEAD 的两种形态。
+	if strings.HasPrefix(branchPart, "HEAD (no branch)") ||
+		strings.HasPrefix(branchPart, "HEAD (detached") ||
+		strings.HasPrefix(branchPart, "(no branch)") {
+		status.Detached = true
+		parseAheadBehind(rest, status)
+		return
+	}
+
+	// 处理 unborn 分支：尚未首次提交时 git 会输出 "No commits yet on <branch>"
+	// 或更早版本的 "Initial commit on <branch>"。此时仍记录分支名，但没有 upstream。
+	switch {
+	case strings.HasPrefix(branchPart, "No commits yet on "):
+		status.CurrentBranch = strings.TrimPrefix(branchPart, "No commits yet on ")
+	case strings.HasPrefix(branchPart, "Initial commit on "):
+		status.CurrentBranch = strings.TrimPrefix(branchPart, "Initial commit on ")
+	default:
+		if before, after, ok := strings.Cut(branchPart, "..."); ok {
+			status.CurrentBranch = before
+			status.Upstream = after
+		} else {
+			status.CurrentBranch = branchPart
+		}
+	}
+
+	parseAheadBehind(rest, status)
+}
+
+// parseAheadBehind 解析 ahead/behind 段（不含外层方括号）。
+func parseAheadBehind(rest string, status *GitStatus) {
+	if rest == "" {
+		return
+	}
+	for _, seg := range strings.Split(rest, ",") {
+		seg = strings.TrimSpace(seg)
+		switch {
+		case strings.HasPrefix(seg, "ahead "):
+			if n, err := strconv.Atoi(strings.TrimPrefix(seg, "ahead ")); err == nil {
+				status.Ahead = n
+			}
+		case strings.HasPrefix(seg, "behind "):
+			if n, err := strconv.Atoi(strings.TrimPrefix(seg, "behind ")); err == nil {
+				status.Behind = n
+			}
+		}
+	}
+}
+
+// parseFileStatusLine 解析 porcelain 输出的单条文件状态行。
+func parseFileStatusLine(line string) (GitFileStatus, bool) {
+	if len(line) < 3 {
+		return GitFileStatus{}, false
+	}
+	x := string(line[0])
+	y := string(line[1])
+	rest := line[3:]
+
+	entry := GitFileStatus{
+		IndexStatus:       x,
+		WorkingTreeStatus: y,
+	}
+
+	// 重命名/复制：路径形如 "old -> new"
+	if x == "R" || x == "C" || y == "R" || y == "C" {
+		if before, after, ok := strings.Cut(rest, " -> "); ok {
+			entry.RenamedFrom = before
+			entry.Name = after
+		} else {
+			entry.Name = rest
+		}
+	} else {
+		entry.Name = rest
+	}
+
+	entry.Status = normalizeFileStatus(x, y)
+	entry.Staged = isStaged(x, entry.Status)
+	return entry, true
+}
+
+// normalizeFileStatus 将 XY 字符归一化为可读状态。
+func normalizeFileStatus(x, y string) string {
+	if x == "?" && y == "?" {
+		return "untracked"
+	}
+	if x == "!" && y == "!" {
+		return "ignored"
+	}
+	if isConflict(x, y) {
+		return "conflict"
+	}
+	// 优先看索引位，其次工作区位
+	if s := mapStatusChar(x); s != "" && s != "unmodified" {
+		return s
+	}
+	if s := mapStatusChar(y); s != "" && s != "unmodified" {
+		return s
+	}
+	return "unmodified"
+}
+
+// mapStatusChar 将单个状态字符映射为可读字符串。
+func mapStatusChar(c string) string {
+	switch c {
+	case " ":
+		return "unmodified"
+	case "M":
+		return "modified"
+	case "A":
+		return "added"
+	case "D":
+		return "deleted"
+	case "R":
+		return "renamed"
+	case "C":
+		return "copied"
+	case "T":
+		return "type-changed"
+	case "U":
+		return "conflict"
+	}
+	return ""
+}
+
+// isConflict 判断 XY 是否构成 git 合并冲突。
+// 参考 git status 文档中 "Unmerged" 表（DD/AU/UD/UA/DU/AA/UU）。
+func isConflict(x, y string) bool {
+	switch x + y {
+	case "DD", "AU", "UD", "UA", "DU", "AA", "UU":
+		return true
+	}
+	return x == "U" || y == "U"
+}
+
+// isStaged 判断条目是否处于已暂存状态。
+func isStaged(x, status string) bool {
+	if status == "untracked" || status == "ignored" || status == "conflict" {
+		return false
+	}
+	if x == " " || x == "?" || x == "!" {
+		return false
+	}
+	return true
+}
+
+// parseGitBranches 解析 `git branch --format=%(refname:short)\t%(HEAD)` 的输出。
+func parseGitBranches(out string) *GitBranches {
+	result := &GitBranches{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
+		}
+		result.Branches = append(result.Branches, name)
+		if len(parts) == 2 && strings.TrimSpace(parts[1]) == "*" {
+			result.CurrentBranch = name
+		}
+	}
+	return result
+}

--- a/sandbox/git_parse.go
+++ b/sandbox/git_parse.go
@@ -234,7 +234,10 @@ func unquoteCPath(s string) string {
 		default:
 			// 三位八进制：\NNN
 			if i+3 < len(body) && isOctal(body[i+1]) && isOctal(body[i+2]) && isOctal(body[i+3]) {
-				v := (int(body[i+1]-'0') << 6) | (int(body[i+2]-'0') << 3) | int(body[i+3]-'0')
+				v, err := strconv.ParseUint(string(body[i+1:i+4]), 8, 8)
+				if err != nil {
+					return s
+				}
 				out = append(out, byte(v))
 				i += 3
 				continue

--- a/sandbox/git_parse.go
+++ b/sandbox/git_parse.go
@@ -216,6 +216,9 @@ func isStaged(x, status string) bool {
 }
 
 // parseGitBranches 解析 `git branch --format=%(refname:short)\t%(HEAD)` 的输出。
+//
+// detached HEAD 时 git 会把 "(HEAD detached at <sha>)" / "(HEAD detached from <ref>)"
+// 作为一项输出并标记为当前 HEAD；这里跳过该伪分支以保持 CurrentBranch 在 HEAD 分离时为空。
 func parseGitBranches(out string) *GitBranches {
 	result := &GitBranches{}
 	for _, line := range strings.Split(out, "\n") {
@@ -228,8 +231,12 @@ func parseGitBranches(out string) *GitBranches {
 		if name == "" {
 			continue
 		}
+		isCurrent := len(parts) == 2 && strings.TrimSpace(parts[1]) == "*"
+		if strings.HasPrefix(name, "(HEAD detached") || name == "(no branch)" {
+			continue
+		}
 		result.Branches = append(result.Branches, name)
-		if len(parts) == 2 && strings.TrimSpace(parts[1]) == "*" {
+		if isCurrent {
 			result.CurrentBranch = name
 		}
 	}

--- a/sandbox/git_parse.go
+++ b/sandbox/git_parse.go
@@ -120,6 +120,10 @@ func parseAheadBehind(rest string, status *GitStatus) {
 }
 
 // parseFileStatusLine 解析 porcelain 输出的单条文件状态行。
+//
+// 当文件名包含空格、双引号或非可打印字符时，git 默认会输出 C-style 引号转义
+// 的路径（如 `?? "with space.txt"`、`R  "old name" -> "new name"`），这里需要
+// 对引号内容做反转义，确保调用方拿到的是真正的相对路径。
 func parseFileStatusLine(line string) (GitFileStatus, bool) {
 	if len(line) < 3 {
 		return GitFileStatus{}, false
@@ -133,22 +137,116 @@ func parseFileStatusLine(line string) (GitFileStatus, bool) {
 		WorkingTreeStatus: y,
 	}
 
-	// 重命名/复制：路径形如 "old -> new"
+	// 重命名/复制：路径形如 "old -> new"，两端可能各自被引号包裹。
 	if x == "R" || x == "C" || y == "R" || y == "C" {
-		if before, after, ok := strings.Cut(rest, " -> "); ok {
-			entry.RenamedFrom = before
-			entry.Name = after
+		if before, after, ok := splitRenamePath(rest); ok {
+			entry.RenamedFrom = unquoteCPath(before)
+			entry.Name = unquoteCPath(after)
 		} else {
-			entry.Name = rest
+			entry.Name = unquoteCPath(rest)
 		}
 	} else {
-		entry.Name = rest
+		entry.Name = unquoteCPath(rest)
 	}
 
 	entry.Status = normalizeFileStatus(x, y)
 	entry.Staged = isStaged(x, entry.Status)
 	return entry, true
 }
+
+// splitRenamePath 拆分 "old -> new" 形式的重命名路径，正确处理两端被引号包裹的情况。
+// 普通情况下直接按 " -> " 切分；若 old 部分以 `"` 开头，则定位到匹配的结束引号后再找 " -> "。
+func splitRenamePath(s string) (string, string, bool) {
+	if strings.HasPrefix(s, `"`) {
+		// 找到第一个未被反斜杠转义的结束引号。
+		i := 1
+		for i < len(s) {
+			if s[i] == '\\' && i+1 < len(s) {
+				i += 2
+				continue
+			}
+			if s[i] == '"' {
+				break
+			}
+			i++
+		}
+		if i >= len(s) {
+			return "", "", false
+		}
+		head := s[:i+1]
+		rest := s[i+1:]
+		const sep = " -> "
+		if strings.HasPrefix(rest, sep) {
+			return head, rest[len(sep):], true
+		}
+		return "", "", false
+	}
+	before, after, ok := strings.Cut(s, " -> ")
+	return before, after, ok
+}
+
+// unquoteCPath 对 git porcelain 输出的 C-style 引号路径做反转义。
+//
+// 输入未以双引号开头时原样返回；否则按 git 的 quote_c_style 规则解析：
+// 支持 \\、\"、\a \b \f \n \r \t \v 以及 \<3-octal> 任意字节。
+// 解析失败时回退到原字符串，避免抛错破坏调用流程。
+func unquoteCPath(s string) string {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return s
+	}
+	body := s[1 : len(s)-1]
+	out := make([]byte, 0, len(body))
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if c != '\\' {
+			out = append(out, c)
+			continue
+		}
+		if i+1 >= len(body) {
+			return s
+		}
+		next := body[i+1]
+		switch next {
+		case '\\', '"', '\'':
+			out = append(out, next)
+			i++
+		case 'a':
+			out = append(out, '\a')
+			i++
+		case 'b':
+			out = append(out, '\b')
+			i++
+		case 'f':
+			out = append(out, '\f')
+			i++
+		case 'n':
+			out = append(out, '\n')
+			i++
+		case 'r':
+			out = append(out, '\r')
+			i++
+		case 't':
+			out = append(out, '\t')
+			i++
+		case 'v':
+			out = append(out, '\v')
+			i++
+		default:
+			// 三位八进制：\NNN
+			if i+3 < len(body) && isOctal(body[i+1]) && isOctal(body[i+2]) && isOctal(body[i+3]) {
+				v := (int(body[i+1]-'0') << 6) | (int(body[i+2]-'0') << 3) | int(body[i+3]-'0')
+				out = append(out, byte(v))
+				i += 3
+				continue
+			}
+			return s
+		}
+	}
+	return string(out)
+}
+
+// isOctal 判断字节是否为八进制数字字符。
+func isOctal(c byte) bool { return c >= '0' && c <= '7' }
 
 // normalizeFileStatus 将 XY 字符归一化为可读状态。
 func normalizeFileStatus(x, y string) string {

--- a/sandbox/git_parse.go
+++ b/sandbox/git_parse.go
@@ -232,17 +232,17 @@ func unquoteCPath(s string) string {
 			out = append(out, '\v')
 			i++
 		default:
-			// 三位八进制：\NNN
+			// 三位八进制：\NNN（git 用它表示非 ASCII 字节，例如 UTF-8 的多字节序列）。
+			// 三位 octal 最大值为 0o777=511，超过 byte 范围时 strconv.ParseUint 会报错；
+			// 此时按"非法转义"处理：保留字面 `\` 并从下一个字符继续解析，避免整段字符串作废。
 			if i+3 < len(body) && isOctal(body[i+1]) && isOctal(body[i+2]) && isOctal(body[i+3]) {
-				v, err := strconv.ParseUint(string(body[i+1:i+4]), 8, 8)
-				if err != nil {
-					return s
+				if v, perr := strconv.ParseUint(string(body[i+1:i+4]), 8, 8); perr == nil {
+					out = append(out, byte(v))
+					i += 3
+					continue
 				}
-				out = append(out, byte(v))
-				i += 3
-				continue
 			}
-			return s
+			out = append(out, '\\')
 		}
 	}
 	return string(out)

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -61,13 +61,22 @@ func TestBuildCommitArgs(t *testing.T) {
 }
 
 func TestBuildResetArgs(t *testing.T) {
-	args, err := buildResetArgs(GitResetModeHard, "HEAD~1", []string{"a.go"})
+	args, err := buildResetArgs(GitResetModeHard, "HEAD~1", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"reset", "--hard", "HEAD~1", "--", "a.go"}, args)
+	assert.Equal(t, []string{"reset", "--hard", "HEAD~1"}, args)
+
+	args, err = buildResetArgs("", "", []string{"a.go"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"reset", "--", "a.go"}, args)
+
+	// mode 与 paths 同时给出会被拒绝（git reset 的两种用法互斥）
+	_, err = buildResetArgs(GitResetModeHard, "HEAD~1", []string{"a.go"})
+	assert.Error(t, err)
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
 
 	_, err = buildResetArgs(GitResetMode("invalid"), "", nil)
 	assert.Error(t, err)
-	var ie *InvalidArgumentError
 	assert.True(t, errors.As(err, &ie))
 }
 
@@ -233,6 +242,23 @@ func TestParseGitBranches(t *testing.T) {
 	b := parseGitBranches(out)
 	assert.Equal(t, []string{"main", "feature", "release"}, b.Branches)
 	assert.Equal(t, "main", b.CurrentBranch)
+}
+
+func TestParseGitBranches_DetachedHEAD(t *testing.T) {
+	// detached HEAD 时 git 会输出 "(HEAD detached at <sha>)" 并标记为当前；
+	// 该伪分支不应进入 Branches，CurrentBranch 也应保持为空。
+	out := "(HEAD detached at 1234abc)\t*\nmain\t \nfeature\t \n"
+	b := parseGitBranches(out)
+	assert.Equal(t, []string{"main", "feature"}, b.Branches)
+	assert.Empty(t, b.CurrentBranch)
+}
+
+func TestUnstagedCount_MMCountedOnce(t *testing.T) {
+	// "MM file" 表示同一文件既有 staged 又有 unstaged 改动，应同时计入两边。
+	s := parseGitStatus("## main\nMM file.go\n M dirty.go\n?? new.go\n")
+	assert.Equal(t, 1, s.StagedCount())
+	assert.Equal(t, 2, s.UnstagedCount())
+	assert.Equal(t, 1, s.UntrackedCount())
 }
 
 func TestIsAuthFailure(t *testing.T) {

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -127,6 +127,22 @@ func TestBuildClonePlan_StoresCredentials(t *testing.T) {
 	assert.False(t, plan.shouldStrip)
 }
 
+// TestBuildClonePlan_RejectsInlineHTTPCredentials 验证调用方直接把凭证嵌入 URL 时也强制 https，
+// 与 withCredentials 注入路径保持一致的安全边界。
+func TestBuildClonePlan_RejectsInlineHTTPCredentials(t *testing.T) {
+	_, err := buildClonePlan("http://alice:tk@example.com/r.git", "/tmp/r", "", 0, "", "", false)
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie), "http+inline 凭证应被拒，实际: %T %v", err, err)
+
+	// https + inline 凭证应允许通过，由后续 strip 处理
+	_, err = buildClonePlan("https://alice:tk@example.com/r.git", "/tmp/r", "", 0, "", "", false)
+	assert.NoError(t, err)
+
+	// 无凭证时不应触发校验，例如 SCP / file 路径
+	_, err = buildClonePlan("git@github.com:o/r.git", "/tmp/r", "", 0, "", "", false)
+	assert.NoError(t, err)
+}
+
 func TestWithCredentials(t *testing.T) {
 	got, err := withCredentials("https://github.com/o/r.git", "alice", "tk:1")
 	assert.NoError(t, err)

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -1,0 +1,273 @@
+//go:build unit
+
+package sandbox
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellEscape(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"simple", "'simple'"},
+		{"a b", "'a b'"},
+		{"it's", `'it'"'"'s'`},
+		{"", "''"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, shellEscape(c.in), "input=%q", c.in)
+	}
+}
+
+func TestBuildGitCommand(t *testing.T) {
+	cmd := buildGitCommand([]string{"status", "--porcelain=1"}, "/repo path")
+	assert.Equal(t, `'git' '-C' '/repo path' 'status' '--porcelain=1'`, cmd)
+
+	cmd = buildGitCommand([]string{"init"}, "")
+	assert.Equal(t, `'git' 'init'`, cmd)
+}
+
+func TestBuildPushPullArgs(t *testing.T) {
+	assert.Equal(t, []string{"push", "--set-upstream", "origin", "main"},
+		buildPushArgs("origin", "main", true))
+	assert.Equal(t, []string{"push"}, buildPushArgs("", "", true))
+	assert.Equal(t, []string{"push", "origin", "main"},
+		buildPushArgs("origin", "main", false))
+
+	assert.Equal(t, []string{"pull", "origin", "main"},
+		buildPullArgs("origin", "main"))
+	assert.Equal(t, []string{"pull"}, buildPullArgs("", ""))
+}
+
+func TestBuildAddArgs(t *testing.T) {
+	assert.Equal(t, []string{"add", "."}, buildAddArgs(nil, false))
+	assert.Equal(t, []string{"add", "-A"}, buildAddArgs(nil, true))
+	assert.Equal(t, []string{"add", "--", "a.go", "b.go"}, buildAddArgs([]string{"a.go", "b.go"}, true))
+}
+
+func TestBuildCommitArgs(t *testing.T) {
+	got := buildCommitArgs("msg", "Alice", "a@x.io", true)
+	assert.Equal(t,
+		[]string{"-c", "user.name=Alice", "-c", "user.email=a@x.io", "commit", "-m", "msg", "--allow-empty"},
+		got,
+	)
+	assert.Equal(t, []string{"commit", "-m", "msg"}, buildCommitArgs("msg", "", "", false))
+}
+
+func TestBuildResetArgs(t *testing.T) {
+	args, err := buildResetArgs(GitResetModeHard, "HEAD~1", []string{"a.go"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"reset", "--hard", "HEAD~1", "--", "a.go"}, args)
+
+	_, err = buildResetArgs(GitResetMode("invalid"), "", nil)
+	assert.Error(t, err)
+	var ie *InvalidArgumentError
+	assert.True(t, errors.As(err, &ie))
+}
+
+func TestBuildRestoreArgs(t *testing.T) {
+	// 默认仅恢复工作区
+	args, err := buildRestoreArgs([]string{"a.go"}, nil, nil, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"restore", "--worktree", "--", "a.go"}, args)
+
+	// staged=true 时默认不恢复工作区
+	tr := true
+	args, err = buildRestoreArgs([]string{"a.go"}, &tr, nil, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"restore", "--staged", "--", "a.go"}, args)
+
+	// 显式两者都开启
+	args, err = buildRestoreArgs([]string{"a.go"}, &tr, &tr, "HEAD")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"restore", "--worktree", "--staged", "--source", "HEAD", "--", "a.go"}, args)
+
+	_, err = buildRestoreArgs(nil, nil, nil, "")
+	assert.Error(t, err)
+}
+
+func TestBuildClonePlan_NoCredentials(t *testing.T) {
+	plan, err := buildClonePlan("https://github.com/o/r.git", "/tmp/r", "main", 1, "", "", false)
+	assert.NoError(t, err)
+	assert.False(t, plan.shouldStrip)
+	assert.Equal(t,
+		[]string{"clone", "https://github.com/o/r.git", "--branch", "main", "--single-branch", "--depth", "1", "/tmp/r"},
+		plan.args,
+	)
+}
+
+func TestBuildClonePlan_StripsCredentials(t *testing.T) {
+	plan, err := buildClonePlan("https://github.com/o/r.git", "", "", 0, "alice", "tk", false)
+	assert.NoError(t, err)
+	assert.True(t, plan.shouldStrip)
+	assert.Equal(t, "https://github.com/o/r.git", plan.sanitizedURL)
+	assert.Equal(t, "r", plan.repoPath)
+	// args[1] 应包含凭证
+	assert.Contains(t, plan.args[1], "alice:tk@")
+}
+
+func TestBuildClonePlan_StoresCredentials(t *testing.T) {
+	plan, err := buildClonePlan("https://github.com/o/r.git", "/tmp/r", "", 0, "alice", "tk", true)
+	assert.NoError(t, err)
+	assert.False(t, plan.shouldStrip)
+}
+
+func TestWithCredentials(t *testing.T) {
+	got, err := withCredentials("https://github.com/o/r.git", "alice", "tk:1")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://alice:tk%3A1@github.com/o/r.git", got)
+
+	// 仅一个不为空 -> 错
+	_, err = withCredentials("https://github.com/o/r.git", "alice", "")
+	assert.Error(t, err)
+
+	// 非 http(s) -> 错
+	_, err = withCredentials("git@github.com:o/r.git", "alice", "tk")
+	assert.Error(t, err)
+
+	// 都为空 -> 原样返回
+	got, err = withCredentials("https://github.com/o/r.git", "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/o/r.git", got)
+}
+
+func TestStripCredentials(t *testing.T) {
+	assert.Equal(t, "https://github.com/o/r.git",
+		stripCredentials("https://alice:tk@github.com/o/r.git"))
+	assert.Equal(t, "https://github.com/o/r.git",
+		stripCredentials("https://github.com/o/r.git"))
+	assert.Equal(t, "git@github.com:o/r.git",
+		stripCredentials("git@github.com:o/r.git"))
+}
+
+func TestDeriveRepoDirFromURL(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/o/r.git":        "r",
+		"https://github.com/o/r":            "r",
+		"git@github.com:o/r.git":            "r",
+		"https://github.com/o/r.git?ref=v1": "r",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, deriveRepoDirFromURL(in), "input=%s", in)
+	}
+}
+
+func TestParseGitStatus_BranchHeader(t *testing.T) {
+	out := "## main...origin/main [ahead 1, behind 2]\n"
+	s := parseGitStatus(out)
+	assert.Equal(t, "main", s.CurrentBranch)
+	assert.Equal(t, "origin/main", s.Upstream)
+	assert.Equal(t, 1, s.Ahead)
+	assert.Equal(t, 2, s.Behind)
+	assert.False(t, s.Detached)
+	assert.True(t, s.IsClean())
+}
+
+func TestParseGitStatus_DetachedAndFiles(t *testing.T) {
+	out := strings.Join([]string{
+		"## HEAD (no branch)",
+		"M  staged.go",
+		" M dirty.go",
+		"?? new.go",
+		"R  old.go -> renamed.go",
+		"UU conflict.go",
+		"",
+	}, "\n")
+	s := parseGitStatus(out)
+	assert.True(t, s.Detached)
+	assert.Equal(t, 5, s.TotalCount())
+	assert.Equal(t, 2, s.StagedCount()) // staged.go + renamed.go
+	assert.True(t, s.HasUntracked())
+	assert.True(t, s.HasConflicts())
+
+	byName := map[string]GitFileStatus{}
+	for _, f := range s.FileStatus {
+		byName[f.Name] = f
+	}
+	assert.Equal(t, "modified", byName["staged.go"].Status)
+	assert.True(t, byName["staged.go"].Staged)
+	assert.Equal(t, "modified", byName["dirty.go"].Status)
+	assert.False(t, byName["dirty.go"].Staged)
+	assert.Equal(t, "untracked", byName["new.go"].Status)
+	assert.Equal(t, "renamed", byName["renamed.go"].Status)
+	assert.Equal(t, "old.go", byName["renamed.go"].RenamedFrom)
+	assert.Equal(t, "conflict", byName["conflict.go"].Status)
+}
+
+func TestParseGitStatus_DetachedAtRef(t *testing.T) {
+	s := parseGitStatus("## HEAD (detached at v1.2.3)\n")
+	assert.True(t, s.Detached)
+	assert.Empty(t, s.CurrentBranch)
+	assert.Empty(t, s.Upstream)
+}
+
+func TestParseGitStatus_UnbornBranch(t *testing.T) {
+	// "git status --porcelain=1 -b" 在仓库尚未首次提交时输出 "## No commits yet on <branch>"
+	s := parseGitStatus("## No commits yet on main\n?? new.go\n")
+	assert.False(t, s.Detached)
+	assert.Equal(t, "main", s.CurrentBranch)
+	assert.Empty(t, s.Upstream)
+	assert.Equal(t, 1, s.UntrackedCount())
+
+	// 旧版 git 用 "Initial commit on" 措辞
+	s = parseGitStatus("## Initial commit on master\n")
+	assert.Equal(t, "master", s.CurrentBranch)
+	assert.False(t, s.Detached)
+}
+
+func TestParseGitStatus_AheadBehindOnly(t *testing.T) {
+	s := parseGitStatus("## main...origin/main [ahead 3]\n")
+	assert.Equal(t, "main", s.CurrentBranch)
+	assert.Equal(t, 3, s.Ahead)
+	assert.Equal(t, 0, s.Behind)
+}
+
+func TestParseGitBranches(t *testing.T) {
+	out := "main\t*\nfeature\t \nrelease\t\n"
+	b := parseGitBranches(out)
+	assert.Equal(t, []string{"main", "feature", "release"}, b.Branches)
+	assert.Equal(t, "main", b.CurrentBranch)
+}
+
+func TestIsAuthFailure(t *testing.T) {
+	err := &gitCommandError{Cmd: "push", Result: &CommandResult{ExitCode: 128, Stderr: "fatal: Authentication failed for foo"}}
+	assert.True(t, isAuthFailure(err))
+	assert.False(t, isMissingUpstream(err))
+
+	err = &gitCommandError{Cmd: "pull", Result: &CommandResult{Stderr: "There is no tracking information for the current branch"}}
+	assert.True(t, isMissingUpstream(err))
+	assert.False(t, isAuthFailure(err))
+
+	assert.False(t, isAuthFailure(errors.New("other")))
+}
+
+func TestResolveConfigScope(t *testing.T) {
+	flag, p, err := resolveConfigScope("", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "--global", flag)
+	assert.Empty(t, p)
+
+	flag, p, err = resolveConfigScope(GitConfigScopeLocal, "/repo")
+	assert.NoError(t, err)
+	assert.Equal(t, "--local", flag)
+	assert.Equal(t, "/repo", p)
+
+	_, _, err = resolveConfigScope(GitConfigScopeLocal, "")
+	assert.Error(t, err)
+
+	_, _, err = resolveConfigScope("weird", "")
+	assert.Error(t, err)
+}
+
+func TestBuildAuthErrorMessage(t *testing.T) {
+	assert.Contains(t, buildAuthErrorMessage("clone", true), "password/token")
+	assert.Contains(t, buildAuthErrorMessage("push", false), "credentials")
+	assert.Contains(t, buildUpstreamErrorMessage("push"), "upstream")
+	assert.Contains(t, buildUpstreamErrorMessage("pull"), "upstream")
+}

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -276,13 +276,13 @@ func TestParseGitStatus_QuotedPaths(t *testing.T) {
 
 func TestUnquoteCPath(t *testing.T) {
 	cases := map[string]string{
-		`plain.txt`:           `plain.txt`,
-		`"with space.txt"`:    `with space.txt`,
-		`"a\"b"`:              `a"b`,
-		`"a\\b"`:              `a\b`,
-		`"tab\there"`:         "tab\there",
-		`"newline\nhere"`:     "newline\nhere",
-		`"unicode\303\251"`:   "unicode\xc3\xa9", // é (UTF-8)
+		`plain.txt`:         `plain.txt`,
+		`"with space.txt"`:  `with space.txt`,
+		`"a\"b"`:            `a"b`,
+		`"a\\b"`:            `a\b`,
+		`"tab\there"`:       "tab\there",
+		`"newline\nhere"`:   "newline\nhere",
+		`"unicode\303\251"`: "unicode\xc3\xa9", // é (UTF-8)
 	}
 	for in, want := range cases {
 		assert.Equal(t, want, unquoteCPath(in), "input=%q", in)

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -97,6 +97,21 @@ func TestBuildRestoreArgs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"restore", "--worktree", "--staged", "--source", "HEAD", "--", "a.go"}, args)
 
+	// staged=false、worktree=nil → 退化到默认 worktree，而不是抛"必须有一个为 true"的错
+	fa := false
+	args, err = buildRestoreArgs([]string{"a.go"}, &fa, nil, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"restore", "--worktree", "--", "a.go"}, args)
+
+	// staged=nil、worktree=false → 同上退化到默认 worktree
+	args, err = buildRestoreArgs([]string{"a.go"}, nil, &fa, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"restore", "--worktree", "--", "a.go"}, args)
+
+	// 显式两者都为 false → 真正没有恢复目标，应报错
+	_, err = buildRestoreArgs([]string{"a.go"}, &fa, &fa, "")
+	assert.Error(t, err)
+
 	_, err = buildRestoreArgs(nil, nil, nil, "")
 	assert.Error(t, err)
 }

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -253,6 +253,42 @@ func TestParseGitBranches_DetachedHEAD(t *testing.T) {
 	assert.Empty(t, b.CurrentBranch)
 }
 
+func TestParseGitStatus_QuotedPaths(t *testing.T) {
+	// porcelain v1 在文件名含空格、引号、非 ASCII 时会输出 C-style 引号路径。
+	out := strings.Join([]string{
+		`?? "with space.txt"`,
+		` M "quote\"name.txt"`,
+		`R  "old name.txt" -> "new name.txt"`,
+		`A  "tab\there.txt"`,
+		"",
+	}, "\n")
+	s := parseGitStatus(out)
+	byName := map[string]GitFileStatus{}
+	for _, f := range s.FileStatus {
+		byName[f.Name] = f
+	}
+	assert.Contains(t, byName, "with space.txt")
+	assert.Contains(t, byName, `quote"name.txt`)
+	assert.Contains(t, byName, "new name.txt")
+	assert.Equal(t, "old name.txt", byName["new name.txt"].RenamedFrom)
+	assert.Contains(t, byName, "tab\there.txt")
+}
+
+func TestUnquoteCPath(t *testing.T) {
+	cases := map[string]string{
+		`plain.txt`:           `plain.txt`,
+		`"with space.txt"`:    `with space.txt`,
+		`"a\"b"`:              `a"b`,
+		`"a\\b"`:              `a\b`,
+		`"tab\there"`:         "tab\there",
+		`"newline\nhere"`:     "newline\nhere",
+		`"unicode\303\251"`:   "unicode\xc3\xa9", // é (UTF-8)
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, unquoteCPath(in), "input=%q", in)
+	}
+}
+
 func TestUnstagedCount_MMCountedOnce(t *testing.T) {
 	// "MM file" 表示同一文件既有 staged 又有 unstaged 改动，应同时计入两边。
 	s := parseGitStatus("## main\nMM file.go\n M dirty.go\n?? new.go\n")

--- a/sandbox/git_test.go
+++ b/sandbox/git_test.go
@@ -140,6 +140,10 @@ func TestWithCredentials(t *testing.T) {
 	_, err = withCredentials("git@github.com:o/r.git", "alice", "tk")
 	assert.Error(t, err)
 
+	// http -> 错（避免凭证暴露在明文链路）
+	_, err = withCredentials("http://github.com/o/r.git", "alice", "tk")
+	assert.Error(t, err)
+
 	// 都为空 -> 原样返回
 	got, err = withCredentials("https://github.com/o/r.git", "", "")
 	assert.NoError(t, err)
@@ -304,6 +308,10 @@ func TestIsAuthFailure(t *testing.T) {
 
 	err = &gitCommandError{Cmd: "pull", Result: &CommandResult{Stderr: "There is no tracking information for the current branch"}}
 	assert.True(t, isMissingUpstream(err))
+	assert.False(t, isAuthFailure(err))
+
+	// 工作树/锁文件等通用的 "Permission denied" 不应被误判为认证失败
+	err = &gitCommandError{Cmd: "clone", Result: &CommandResult{ExitCode: 128, Stderr: "fatal: could not create work tree dir 'foo': Permission denied"}}
 	assert.False(t, isAuthFailure(err))
 
 	assert.False(t, isAuthFailure(errors.New("other")))

--- a/sandbox/git_types.go
+++ b/sandbox/git_types.go
@@ -88,9 +88,20 @@ func (s *GitStatus) StagedCount() int {
 	return n
 }
 
-// UnstagedCount 返回未暂存的文件数。
+// UnstagedCount 返回存在未暂存改动的文件数。
+// 同一文件既有 staged 又有 unstaged 改动（如 "MM file"）时也会被计入。
 func (s *GitStatus) UnstagedCount() int {
-	return len(s.FileStatus) - s.StagedCount()
+	n := 0
+	for i := range s.FileStatus {
+		f := &s.FileStatus[i]
+		if f.Status == "untracked" || f.Status == "ignored" {
+			continue
+		}
+		if f.WorkingTreeStatus != "" && f.WorkingTreeStatus != " " {
+			n++
+		}
+	}
+	return n
 }
 
 // UntrackedCount 返回未跟踪的文件数。

--- a/sandbox/git_types.go
+++ b/sandbox/git_types.go
@@ -97,7 +97,7 @@ func (s *GitStatus) UnstagedCount() int {
 		if f.Status == "untracked" || f.Status == "ignored" {
 			continue
 		}
-		if f.WorkingTreeStatus != "" && f.WorkingTreeStatus != " " {
+		if f.WorkingTreeStatus != " " {
 			n++
 		}
 	}

--- a/sandbox/git_types.go
+++ b/sandbox/git_types.go
@@ -1,0 +1,136 @@
+package sandbox
+
+// GitFileStatus 描述单个文件的 git 状态条目。
+type GitFileStatus struct {
+	// Name 是相对于仓库根目录的路径。
+	Name string
+	// Status 是归一化后的状态字符串，例如 "modified"、"added"、"deleted"、"untracked"、"conflict" 等。
+	Status string
+	// IndexStatus 是 porcelain 输出中索引位的字符。
+	IndexStatus string
+	// WorkingTreeStatus 是 porcelain 输出中工作区位的字符。
+	WorkingTreeStatus string
+	// Staged 表示该文件是否已暂存。
+	Staged bool
+	// RenamedFrom 在文件被重命名时记录原路径。
+	RenamedFrom string
+}
+
+// GitStatus 描述仓库整体状态。
+type GitStatus struct {
+	// CurrentBranch 是当前分支名，HEAD 分离时为空。
+	CurrentBranch string
+	// Upstream 是上游分支名，未配置时为空。
+	Upstream string
+	// Ahead 是当前分支领先上游的提交数。
+	Ahead int
+	// Behind 是当前分支落后上游的提交数。
+	Behind int
+	// Detached 表示 HEAD 是否处于分离状态。
+	Detached bool
+	// FileStatus 是所有有变更的文件状态条目。
+	FileStatus []GitFileStatus
+}
+
+// IsClean 在仓库无任何文件变更时返回 true。
+func (s *GitStatus) IsClean() bool {
+	return len(s.FileStatus) == 0
+}
+
+// HasChanges 在仓库存在任意文件变更时返回 true。
+func (s *GitStatus) HasChanges() bool {
+	return len(s.FileStatus) > 0
+}
+
+// HasStaged 在至少一个文件存在已暂存变更时返回 true。
+func (s *GitStatus) HasStaged() bool {
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Staged {
+			return true
+		}
+	}
+	return false
+}
+
+// HasUntracked 在存在未跟踪文件时返回 true。
+func (s *GitStatus) HasUntracked() bool {
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Status == "untracked" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasConflicts 在存在冲突文件时返回 true。
+func (s *GitStatus) HasConflicts() bool {
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Status == "conflict" {
+			return true
+		}
+	}
+	return false
+}
+
+// TotalCount 返回有变更的文件总数。
+func (s *GitStatus) TotalCount() int {
+	return len(s.FileStatus)
+}
+
+// StagedCount 返回已暂存的文件数。
+func (s *GitStatus) StagedCount() int {
+	n := 0
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Staged {
+			n++
+		}
+	}
+	return n
+}
+
+// UnstagedCount 返回未暂存的文件数。
+func (s *GitStatus) UnstagedCount() int {
+	return len(s.FileStatus) - s.StagedCount()
+}
+
+// UntrackedCount 返回未跟踪的文件数。
+func (s *GitStatus) UntrackedCount() int {
+	n := 0
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Status == "untracked" {
+			n++
+		}
+	}
+	return n
+}
+
+// ConflictCount 返回冲突文件数。
+func (s *GitStatus) ConflictCount() int {
+	n := 0
+	for i := range s.FileStatus {
+		if s.FileStatus[i].Status == "conflict" {
+			n++
+		}
+	}
+	return n
+}
+
+// GitBranches 描述仓库的分支列表。
+type GitBranches struct {
+	// Branches 是所有本地分支名。
+	Branches []string
+	// CurrentBranch 是当前分支名，HEAD 分离时为空。
+	CurrentBranch string
+}
+
+// GitConfigScope 描述 git config 命令的作用域。
+type GitConfigScope string
+
+const (
+	// GitConfigScopeGlobal 表示用户级配置（~/.gitconfig）。
+	GitConfigScopeGlobal GitConfigScope = "global"
+	// GitConfigScopeLocal 表示仓库级配置（<repo>/.git/config），需要同时提供仓库路径。
+	GitConfigScopeLocal GitConfigScope = "local"
+	// GitConfigScopeSystem 表示系统级配置（/etc/gitconfig）。
+	GitConfigScopeSystem GitConfigScope = "system"
+)

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -55,6 +55,9 @@ type Sandbox struct {
 
 	ptyOnce sync.Once
 	pty     *Pty
+
+	gitOnce sync.Once
+	git     *Git
 }
 
 // newSandbox 从 API 响应创建 Sandbox 实例。
@@ -362,6 +365,15 @@ func (s *Sandbox) Pty() *Pty {
 		s.pty = newPty(s, s.processClient())
 	})
 	return s.pty
+}
+
+// Git 返回 git 操作接口。
+// 沙箱内需预装 git 二进制；当前仅支持 HTTPS + username/password (token) 认证。
+func (s *Sandbox) Git() *Git {
+	s.gitOnce.Do(func() {
+		s.git = newGit(s.Commands())
+	})
+	return s.git
 }
 
 // GetHost 返回访问沙箱指定端口的外部域名。


### PR DESCRIPTION
## Summary

- 在 `sandbox` 包内新增 `Git` 高层封装，提供仓库克隆、状态查询、分支管理、提交、推送拉取、配置等完整 git 操作能力。
- 仅支持 HTTPS + username/password (token) 认证，不支持 SSH key；所有命令强制注入 `GIT_TERMINAL_PROMPT=0` 禁用交互式提示。
- 凭证安全：clone 默认在完成后从 `origin` URL 中剥离，push/pull 期间将凭证临时写入目标 remote URL，命令完成后恢复原 URL（即使 ctx 已取消）；提供 `DangerouslyAuthenticate` 用于显式持久化。
- API 风格采用 Options Struct，与 sandbox 现有 API 保持一致。

## 主要 API

| 方法 | 说明 |
|------|------|
| `Clone` / `Init` | 克隆/初始化仓库 |
| `Status` / `Branches` | 解析 porcelain 输出，覆盖 detached HEAD、unborn 分支、ahead/behind、重命名、冲突等场景 |
| `CreateBranch` / `CheckoutBranch` / `DeleteBranch` | 分支管理 |
| `Add` / `Commit` / `Reset` / `Restore` | 工作区/索引操作 |
| `Push` / `Pull` | 远程同步，支持可选凭证注入；未指定 remote 时通过 \`git remote\` 列表自动选择单一 remote |
| `RemoteAdd` / `RemoteGet` | remote 管理 |
| `SetConfig` / `GetConfig` / `ConfigureUser` | git config，支持 global/system/local scope |
| `DangerouslyAuthenticate` | 通过 credential helper 持久化凭证 |

## 文件结构

- `sandbox/git.go` — Git 高层方法
- `sandbox/git_options.go` — Options Struct 定义
- `sandbox/git_args.go` — 命令参数构建（纯函数，便于测试）
- `sandbox/git_parse.go` — porcelain/branch 输出解析
- `sandbox/git_auth.go` — 凭证 URL 注入/剥离、错误识别与类型化
- `sandbox/git_types.go` — `GitStatus`/`GitFileStatus`/`GitBranches`/`GitConfigScope`
- `sandbox/git_test.go` — 单元测试（\`//go:build unit\`）
- `sandbox/sandbox.go` — 新增 `Sandbox.Git()` 懒初始化访问器

## Test plan

- [x] `go test -tags=unit ./sandbox/` 通过
- [x] `make staticcheck` 通过
- [x] 解析器覆盖 detached HEAD、unborn 分支、ahead/behind 仅 ahead 等边界
- [x] 凭证流程：clone 后 strip、push/pull 期间临时注入并显式恢复（操作错误优先返回，操作成功但恢复失败时返回恢复错误）
- [x] 集成测试（需要真实沙箱环境，未在本 PR 中运行）