### PR TITLE
fix(sandbox): 修复 Commands.Connect 因重复关闭 pidCh 导致 panic

### DIFF
--- a/sandbox/commands.go
+++ b/sandbox/commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -22,7 +23,9 @@ type CommandResult struct {
 
 // CommandHandle 后台命令句柄。
 type CommandHandle struct {
-	pid uint32
+	// pid 进程 ID。Start 路径下由后台事件流 goroutine 写入，
+	// 因此使用 atomic 保证与 PID()/Kill() 的并发读取之间无数据竞态。
+	pid atomic.Uint32
 
 	commands *Commands
 	cancel   context.CancelFunc
@@ -43,14 +46,14 @@ type CommandHandle struct {
 // 避免共享事件流处理器后续再收到 Start 事件时重复 close(pidCh) 引发 panic。
 func (h *CommandHandle) markPIDReady(pid uint32) {
 	h.pidOnce.Do(func() {
-		h.pid = pid
+		h.pid.Store(pid)
 		close(h.pidCh)
 	})
 }
 
 // PID 返回进程 ID。
 func (h *CommandHandle) PID() uint32 {
-	return h.pid
+	return h.pid.Load()
 }
 
 // Wait 等待命令完成并返回结果。
@@ -64,7 +67,7 @@ func (h *CommandHandle) Wait() (*CommandResult, error) {
 
 // Kill 终止命令。
 func (h *CommandHandle) Kill(ctx context.Context) error {
-	return h.commands.Kill(ctx, h.pid)
+	return h.commands.Kill(ctx, h.pid.Load())
 }
 
 // WaitPID 等待进程 PID 被分配。
@@ -72,7 +75,7 @@ func (h *CommandHandle) Kill(ctx context.Context) error {
 func (h *CommandHandle) WaitPID(ctx context.Context) (uint32, error) {
 	select {
 	case <-h.pidCh:
-		return h.pid, nil
+		return h.pid.Load(), nil
 	case <-ctx.Done():
 		return 0, ctx.Err()
 	}

--- a/sandbox/commands.go
+++ b/sandbox/commands.go
@@ -28,12 +28,24 @@ type CommandHandle struct {
 	cancel   context.CancelFunc
 	done     chan struct{}
 	pidCh    chan struct{}
+	pidOnce  sync.Once
 	result   *CommandResult
 
 	mu        sync.Mutex
 	onStdout  func(data []byte)
 	onStderr  func(data []byte)
 	onPtyData func(data []byte)
+}
+
+// markPIDReady 标记进程 PID 就绪：首次调用写入 pid 并关闭 pidCh，
+// 后续调用为 no-op。Start 路径在收到 Start 事件时调用；
+// Connect 路径在构造 handle 后立即以已知 PID 调用，
+// 避免共享事件流处理器后续再收到 Start 事件时重复 close(pidCh) 引发 panic。
+func (h *CommandHandle) markPIDReady(pid uint32) {
+	h.pidOnce.Do(func() {
+		h.pid = pid
+		close(h.pidCh)
+	})
 }
 
 // PID 返回进程 ID。
@@ -250,8 +262,7 @@ func processEventStream[T eventMessage](stream streamReceiver[T], handle *Comman
 		}
 		switch ev := event.Event.(type) {
 		case *process.ProcessEvent_Start:
-			handle.pid = ev.Start.Pid
-			close(handle.pidCh)
+			handle.markPIDReady(ev.Start.Pid)
 		case *process.ProcessEvent_Data:
 			if data := ev.Data.GetStdout(); len(data) > 0 {
 				stdout = append(stdout, data...)
@@ -321,16 +332,15 @@ func (c *Commands) Connect(ctx context.Context, pid uint32) (*CommandHandle, err
 		return nil, fmt.Errorf("connect to process: %w", err)
 	}
 
-	pidCh := make(chan struct{})
-	close(pidCh) // PID 已知，无需等待
-
 	handle := &CommandHandle{
-		pid:      pid,
 		commands: c,
 		cancel:   connectCancel,
 		done:     make(chan struct{}),
-		pidCh:    pidCh,
+		pidCh:    make(chan struct{}),
 	}
+	// PID 已知，立即标记就绪；后续若服务端在流里再发 Start 事件，
+	// markPIDReady 内部的 sync.Once 会保证不会重复 close(pidCh)。
+	handle.markPIDReady(pid)
 
 	go processEventStream(stream, handle)
 

--- a/sandbox/envd_rpc_test.go
+++ b/sandbox/envd_rpc_test.go
@@ -86,6 +86,7 @@ type testProcessHandler struct {
 	processconnect.UnimplementedProcessHandler
 
 	startFn      func(context.Context, *connect.Request[process.StartRequest], *connect.ServerStream[process.StartResponse]) error
+	connectFn    func(context.Context, *connect.Request[process.ConnectRequest], *connect.ServerStream[process.ConnectResponse]) error
 	listFn       func(context.Context, *connect.Request[process.ListRequest]) (*connect.Response[process.ListResponse], error)
 	sendInputFn  func(context.Context, *connect.Request[process.SendInputRequest]) (*connect.Response[process.SendInputResponse], error)
 	sendSignalFn func(context.Context, *connect.Request[process.SendSignalRequest]) (*connect.Response[process.SendSignalResponse], error)
@@ -98,6 +99,13 @@ func (h *testProcessHandler) Start(ctx context.Context, req *connect.Request[pro
 		return h.startFn(ctx, req, stream)
 	}
 	return h.UnimplementedProcessHandler.Start(ctx, req, stream)
+}
+
+func (h *testProcessHandler) Connect(ctx context.Context, req *connect.Request[process.ConnectRequest], stream *connect.ServerStream[process.ConnectResponse]) error {
+	if h.connectFn != nil {
+		return h.connectFn(ctx, req, stream)
+	}
+	return h.UnimplementedProcessHandler.Connect(ctx, req, stream)
 }
 
 func (h *testProcessHandler) List(ctx context.Context, req *connect.Request[process.ListRequest]) (*connect.Response[process.ListResponse], error) {
@@ -1038,6 +1046,64 @@ func TestCommandsRunWithError(t *testing.T) {
 	}
 	if result.Error != "command failed" {
 		t.Errorf("Error = %q, want %q", result.Error, "command failed")
+	}
+}
+
+// TestCommandsConnectWithStartEvent 回归测试 issue #215：
+// Commands.Connect 路径下若服务端流仍下发 Start 事件，
+// 共享的 processEventStream 不应再次 close 已关闭的 pidCh 而 panic。
+func TestCommandsConnectWithStartEvent(t *testing.T) {
+	const targetPID uint32 = 4242
+	handler := &testProcessHandler{
+		connectFn: func(_ context.Context, req *connect.Request[process.ConnectRequest], stream *connect.ServerStream[process.ConnectResponse]) error {
+			// 校验请求里携带的是按 PID 选择
+			if got := req.Msg.GetProcess().GetPid(); got != targetPID {
+				t.Errorf("Connect pid selector = %d, want %d", got, targetPID)
+			}
+			// 服务端先发 Start 事件，再发 End — 触发 panic 的最小复现
+			if err := stream.Send(&process.ConnectResponse{
+				Event: &process.ProcessEvent{
+					Event: &process.ProcessEvent_Start{
+						Start: &process.ProcessEvent_StartEvent{Pid: targetPID},
+					},
+				},
+			}); err != nil {
+				return err
+			}
+			return stream.Send(&process.ConnectResponse{
+				Event: &process.ProcessEvent{
+					Event: &process.ProcessEvent_End{
+						End: &process.ProcessEvent_EndEvent{ExitCode: 0, Status: "exited"},
+					},
+				},
+			})
+		},
+	}
+	cmd, ts := newTestCommands(handler)
+	defer ts.Close()
+
+	handle, err := cmd.Connect(context.Background(), targetPID)
+	if err != nil {
+		t.Fatalf("Connect error: %v", err)
+	}
+
+	pid, err := handle.WaitPID(context.Background())
+	if err != nil {
+		t.Fatalf("WaitPID error: %v", err)
+	}
+	if pid != targetPID {
+		t.Errorf("WaitPID = %d, want %d", pid, targetPID)
+	}
+
+	result, err := handle.Wait()
+	if err != nil {
+		t.Fatalf("Wait error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if handle.PID() != targetPID {
+		t.Errorf("PID() = %d, want %d", handle.PID(), targetPID)
 	}
 }
 

--- a/sandbox/envd_rpc_test.go
+++ b/sandbox/envd_rpc_test.go
@@ -1052,58 +1052,85 @@ func TestCommandsRunWithError(t *testing.T) {
 // TestCommandsConnectWithStartEvent 回归测试 issue #215：
 // Commands.Connect 路径下若服务端流仍下发 Start 事件，
 // 共享的 processEventStream 不应再次 close 已关闭的 pidCh 而 panic。
+//
+// 同时锁定 PID 优先级语义：Connect 由调用方传入 PID，
+// 即便服务端 Start 事件携带不同 PID，也应以调用方传入的为准
+// （由 markPIDReady 内部的 sync.Once 保证首次写入获胜）。
 func TestCommandsConnectWithStartEvent(t *testing.T) {
-	const targetPID uint32 = 4242
-	handler := &testProcessHandler{
-		connectFn: func(_ context.Context, req *connect.Request[process.ConnectRequest], stream *connect.ServerStream[process.ConnectResponse]) error {
-			// 校验请求里携带的是按 PID 选择
-			if got := req.Msg.GetProcess().GetPid(); got != targetPID {
-				t.Errorf("Connect pid selector = %d, want %d", got, targetPID)
-			}
-			// 服务端先发 Start 事件，再发 End — 触发 panic 的最小复现
-			if err := stream.Send(&process.ConnectResponse{
-				Event: &process.ProcessEvent{
-					Event: &process.ProcessEvent_Start{
-						Start: &process.ProcessEvent_StartEvent{Pid: targetPID},
-					},
-				},
-			}); err != nil {
-				return err
-			}
-			return stream.Send(&process.ConnectResponse{
-				Event: &process.ProcessEvent{
-					Event: &process.ProcessEvent_End{
-						End: &process.ProcessEvent_EndEvent{ExitCode: 0, Status: "exited"},
-					},
-				},
-			})
+	tests := []struct {
+		name           string
+		callerPID      uint32
+		serverStartPID uint32
+	}{
+		{
+			name:           "matching pid",
+			callerPID:      4242,
+			serverStartPID: 4242,
+		},
+		{
+			// 守护 PR 描述里声明的契约：调用方传入的 PID 获胜，
+			// 避免未来重构在 markPIDReady 中改成"后写入覆盖前者"而无测试报警。
+			name:           "server start pid mismatches caller pid",
+			callerPID:      4242,
+			serverStartPID: 9999,
 		},
 	}
-	cmd, ts := newTestCommands(handler)
-	defer ts.Close()
 
-	handle, err := cmd.Connect(context.Background(), targetPID)
-	if err != nil {
-		t.Fatalf("Connect error: %v", err)
-	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			handler := &testProcessHandler{
+				connectFn: func(_ context.Context, req *connect.Request[process.ConnectRequest], stream *connect.ServerStream[process.ConnectResponse]) error {
+					// 校验请求里携带的是按 PID 选择
+					if got := req.Msg.GetProcess().GetPid(); got != tc.callerPID {
+						t.Errorf("Connect pid selector = %d, want %d", got, tc.callerPID)
+					}
+					// 服务端先发 Start 事件，再发 End — 触发 panic 的最小复现
+					if err := stream.Send(&process.ConnectResponse{
+						Event: &process.ProcessEvent{
+							Event: &process.ProcessEvent_Start{
+								Start: &process.ProcessEvent_StartEvent{Pid: tc.serverStartPID},
+							},
+						},
+					}); err != nil {
+						return err
+					}
+					return stream.Send(&process.ConnectResponse{
+						Event: &process.ProcessEvent{
+							Event: &process.ProcessEvent_End{
+								End: &process.ProcessEvent_EndEvent{ExitCode: 0, Status: "exited"},
+							},
+						},
+					})
+				},
+			}
+			cmd, ts := newTestCommands(handler)
+			defer ts.Close()
 
-	pid, err := handle.WaitPID(context.Background())
-	if err != nil {
-		t.Fatalf("WaitPID error: %v", err)
-	}
-	if pid != targetPID {
-		t.Errorf("WaitPID = %d, want %d", pid, targetPID)
-	}
+			handle, err := cmd.Connect(context.Background(), tc.callerPID)
+			if err != nil {
+				t.Fatalf("Connect error: %v", err)
+			}
 
-	result, err := handle.Wait()
-	if err != nil {
-		t.Fatalf("Wait error: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
-	}
-	if handle.PID() != targetPID {
-		t.Errorf("PID() = %d, want %d", handle.PID(), targetPID)
+			pid, err := handle.WaitPID(context.Background())
+			if err != nil {
+				t.Fatalf("WaitPID error: %v", err)
+			}
+			if pid != tc.callerPID {
+				t.Errorf("WaitPID = %d, want caller pid %d", pid, tc.callerPID)
+			}
+
+			result, err := handle.Wait()
+			if err != nil {
+				t.Fatalf("Wait error: %v", err)
+			}
+			if result.ExitCode != 0 {
+				t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+			}
+			if handle.PID() != tc.callerPID {
+				t.Errorf("PID() = %d, want caller pid %d", handle.PID(), tc.callerPID)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

修复 #215：`Commands.Connect` 在某些情况下会因为 `pidCh` 被重复关闭而触发 `panic: close of closed channel`。

`processEventStream` 是 `Start` 与 `Connect` 共用的事件流处理器，在收到 `ProcessEvent_Start` 事件时会 `close(handle.pidCh)`；而 `Commands.Connect` 此前会预先 `close` 一个已知 PID 的 `pidCh`。一旦 Connect 流里仍下发 Start 事件，就会触发二次 close 引发 panic。

### 修复思路

将 `pidCh` 的关闭语义收敛到 `CommandHandle.markPIDReady`：内部用 `sync.Once` 保证 `pid` 写入与 channel 关闭只发生一次。

- `Connect` 路径在构造 handle 后立即调用 `markPIDReady(pid)` 标记 PID 已知。
- `processEventStream` 收到 `Start` 事件时改为调用同一方法，幂等安全。
- `Pty.Connect` 复用 `Commands.Connect`，同步受益。
- `pid` 字段改为 `sync/atomic.Uint32`：Start 路径下 `pid` 由后台事件流 goroutine 写入，`PID()` / `Kill()` 可能从其他 goroutine 直接读取，原来仅靠 `pidCh` 关闭建立的 happens-before 只覆盖"先 `WaitPID` 再读"的用法；改用 atomic 后无论调用顺序都无数据竞态。

### 边界说明

`Connect` 路径下若服务端 Start 事件携带与请求不同的 PID，`sync.Once` 保证以调用方传入的 PID 为准（首次写入获胜），代码注释中已说明，并由测试用例守护。

### Non-goal

本 PR 不改变 `CommandHandle.Kill` 在 PID 尚未就绪时的行为。该路径涉及 `processEventStream` 异常退出时 `pidCh` / `done` 的生命周期语义，需要单独设计和测试；直接在 `Kill` 中调用 `WaitPID` 可能在未收到 Start 事件且调用方传入 `context.Background()` 时导致永久阻塞。

## Test plan

- [x] 新增 `TestCommandsConnectWithStartEvent` 回归用例（table-driven，两个子用例）：
  - `matching pid`：服务端 Start 事件 PID 与调用方传入的一致，断言不 panic 且 `WaitPID` / `PID()` / `Wait` 返回预期结果。
  - `server start pid mismatches caller pid`：服务端下发不同的 PID，断言 `WaitPID` / `PID()` 仍返回调用方传入的 PID，把"调用方 PID 获胜"的契约固化。
- [x] `go test -tags=unit -count=1 -run TestCommandsConnectWithStartEvent ./sandbox/...` 通过
- [x] `go test -tags=unit -race ./sandbox/...` 通过（验证 atomic 改动后无数据竞态）
- [x] `make unittest` 通过
- [x] `make staticcheck` 通过
- [x] `gofmt -s` 无差异

Fixes #215