### PR TITLE
chore: release v7.26.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 7.26.11
+
+* 新增
+  * sandbox: 添加 Git 操作 API 支持
+  * sandbox: 添加 GitHub 凭证注入与 Git 仓库资源挂载配置支持
+* 修复
+  * sandbox: 修复 Commands.Connect 因重复关闭 pidCh 导致 panic
+
 ## 7.26.10
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.10
+require github.com/qiniu/go-sdk/v7 v7.26.11
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.10"
+const Version = "7.26.11"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## 变更内容

- 将 SDK 版本号更新到 v7.26.11
- 更新 README 中的 go.mod 版本示例
- 更新 CHANGELOG，包含 sandbox Git 操作 API、GitHub 凭证注入与 Git 仓库资源挂载配置，以及 Commands.Connect panic 修复

## 验证

- gofmt -s -l .
- make staticcheck
- make unittest
