### PR TITLE
chore: release v7.26.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ go.work
 # Log files
 *.log
 
+# Local environment files
+.env
+.env.*
+
 # AI tool local settings
 .claude/settings.local.json
 .cursor/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ go.work
 # Local environment files
 .env
 .env.*
+!.env.example
 
 # AI tool local settings
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 7.26.12
+
+* 修复
+  * sandbox: 修正 GitRepositoryResource 的必填字段说明，并在 SDK 侧校验 URL、MountPath 和 AuthorizationToken 非空
+
 ## 7.26.11
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.11
+require github.com/qiniu/go-sdk/v7 v7.26.12
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.11"
+const Version = "7.26.12"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## Summary

- bump SDK version references to v7.26.12
- add v7.26.12 changelog entry for the sandbox GitRepositoryResource validation fix from #218
- ignore local `.env` and `.env.*` files

## Validation

- `gofmt -s -l .`
- `make staticcheck`
- `make unittest`
