### PR TITLE
feat(sandbox): support Kodo bucket resources

### DIFF
--- a/examples/sandbox_resources/.env.example
+++ b/examples/sandbox_resources/.env.example
@@ -1,0 +1,36 @@
+# Sandbox resource example configuration.
+# Copy this file to examples/sandbox_resources/.env or set these variables in your shell.
+
+# Required for all sandbox API calls.
+QINIU_API_KEY=
+
+# Optional sandbox API endpoint. Leave empty to use the SDK default endpoint.
+QINIU_SANDBOX_API_URL=
+
+# GitHub repository resource.
+# Set both GITHUB_TOKEN and QINIU_SANDBOX_GIT_REPO_URL to enable Git repository
+# mounting and basic write/status checks.
+GITHUB_TOKEN=
+QINIU_SANDBOX_GIT_REPO_URL=
+QINIU_SANDBOX_GIT_TEST_FILE=sandbox-resource-write-test.txt
+
+# Keep push disabled unless you intentionally want the example to commit and push.
+QINIU_SANDBOX_GIT_PUSH_TEST=false
+QINIU_SANDBOX_GIT_PUSH_BRANCH=
+QINIU_SANDBOX_GIT_COMMIT_NAME="Sandbox Resource Demo"
+QINIU_SANDBOX_GIT_COMMIT_EMAIL=sandbox-resource-demo@example.com
+QINIU_SANDBOX_GIT_COMMIT_MESSAGE="test: update sandbox resource write file"
+
+# Kodo bucket resource.
+# Set QINIU_SANDBOX_KODO_BUCKET to enable Kodo mounting.
+# Kodo resources require Qiniu AK/SK credentials on the client.
+QINIU_ACCESS_KEY=
+QINIU_SECRET_KEY=
+QINIU_SANDBOX_KODO_BUCKET=
+QINIU_SANDBOX_KODO_MOUNT_PATH=/workspace/kodo
+QINIU_SANDBOX_KODO_PREFIX=
+QINIU_SANDBOX_KODO_READ_ONLY=true
+QINIU_SANDBOX_KODO_TEST_FILE=sandbox-resource-write-test.txt
+
+# Keep write disabled for a safe first run. Set true to write a test file into the mounted bucket.
+QINIU_SANDBOX_KODO_WRITE_TEST=false

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -1,28 +1,67 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"path"
+	"strings"
+	"time"
 
 	"github.com/qiniu/go-sdk/v7/sandbox"
 )
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Fatalf("%v", r)
+		}
+	}()
+
+	loadEnvFileIfExists("examples/sandbox_resources/.env", ".env")
+
 	// 确保设置了环境变量 QINIU_API_KEY
 	apiKey := os.Getenv("QINIU_API_KEY")
 	if apiKey == "" {
 		log.Fatal("请设置 QINIU_API_KEY 环境变量")
 	}
 
-	apiURL := os.Getenv("QINIU_SANDBOX_API_URL")
+	apiURL := strings.TrimSpace(os.Getenv("QINIU_SANDBOX_API_URL"))
 
-	// 演示用的 GitHub 仓库与 token，可通过环境变量覆盖
+	// 演示用的 GitHub 仓库与 token，可通过环境变量覆盖。
 	repoURL := os.Getenv("QINIU_SANDBOX_GIT_REPO_URL")
 	if repoURL == "" {
 		repoURL = "https://github.com/qiniu/go-sdk.git"
 	}
-	githubToken := os.Getenv("GITHUB_TOKEN") // 私有仓库必填，公共仓库可留空
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	gitMountPath := "/workspace/repo"
+	gitPushTest := envBool("QINIU_SANDBOX_GIT_PUSH_TEST", false)
+	gitTestFile := os.Getenv("QINIU_SANDBOX_GIT_TEST_FILE")
+	if gitTestFile == "" {
+		gitTestFile = "sandbox-resource-write-test.txt"
+	}
+	gitCommitName := envDefault("QINIU_SANDBOX_GIT_COMMIT_NAME", "Sandbox Resource Demo")
+	gitCommitEmail := envDefault("QINIU_SANDBOX_GIT_COMMIT_EMAIL", "sandbox-resource-demo@example.com")
+	gitCommitMessage := envDefault("QINIU_SANDBOX_GIT_COMMIT_MESSAGE", "test: update sandbox resource write file")
+	gitPushBranch := os.Getenv("QINIU_SANDBOX_GIT_PUSH_BRANCH")
+
+	// 演示用的 Kodo 存储桶资源。设置 QINIU_SANDBOX_KODO_BUCKET 后启用。
+	kodoBucket := os.Getenv("QINIU_SANDBOX_KODO_BUCKET")
+	kodoMountPath := os.Getenv("QINIU_SANDBOX_KODO_MOUNT_PATH")
+	if kodoMountPath == "" {
+		kodoMountPath = "/workspace/kodo"
+	}
+	kodoPrefix := os.Getenv("QINIU_SANDBOX_KODO_PREFIX")
+	kodoReadOnly := os.Getenv("QINIU_SANDBOX_KODO_READ_ONLY")
+	kodoAccessKey := os.Getenv("QINIU_ACCESS_KEY")
+	kodoSecretKey := os.Getenv("QINIU_SECRET_KEY")
+	kodoWriteTest := envBool("QINIU_SANDBOX_KODO_WRITE_TEST", true)
+	kodoTestFile := os.Getenv("QINIU_SANDBOX_KODO_TEST_FILE")
+	if kodoTestFile == "" {
+		kodoTestFile = "sandbox-resource-write-test.txt"
+	}
 
 	ctx := context.Background()
 
@@ -35,26 +74,54 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	log.Println("Creating sandbox with GitHub repository resource...")
+	resources := make([]sandbox.SandboxResourceSpec, 0, 2)
+	pathsToList := make([]string, 0, 2)
 
-	// 通过 Resources 在沙箱启动前由平台拉取 GitHub 仓库快照并挂载到 /workspace/repo。
-	// 通过 Injections 注入 GitHub 凭证，使沙箱内对 github.com / api.github.com 的
-	// HTTPS 请求自动鉴权（token 不会以明文形式暴露给沙箱内进程）。
-	repoResource := sandbox.GitRepositoryResource{
-		Type:      sandbox.GitRepositoryTypeGithub,
-		URL:       repoURL,
-		MountPath: "/workspace/repo",
-	}
 	if githubToken != "" {
-		repoResource.AuthorizationToken = &githubToken
+		// 通过 Resources 在沙箱启动前由平台拉取 GitHub 仓库快照并挂载到 /workspace/repo。
+		repoResource := sandbox.GitRepositoryResource{
+			Type:               sandbox.GitRepositoryTypeGithub,
+			URL:                repoURL,
+			MountPath:          gitMountPath,
+			AuthorizationToken: &githubToken,
+		}
+		resources = append(resources, sandbox.SandboxResourceSpec{GitRepository: &repoResource})
+		pathsToList = append(pathsToList, repoResource.MountPath)
+	}
+
+	if kodoBucket != "" {
+		// 通过 Resources 在沙箱启动前将 Kodo 存储桶挂载到指定路径。
+		kodoResource := sandbox.KodoResource{
+			Bucket:    kodoBucket,
+			MountPath: kodoMountPath,
+		}
+		if kodoPrefix != "" {
+			kodoResource.Prefix = &kodoPrefix
+		}
+		if kodoReadOnly != "" {
+			readOnly := kodoReadOnly == "true"
+			kodoResource.ReadOnly = &readOnly
+		}
+		if kodoAccessKey != "" {
+			kodoResource.AccessKey = &kodoAccessKey
+		}
+		if kodoSecretKey != "" {
+			kodoResource.SecretKey = &kodoSecretKey
+		}
+		resources = append(resources, sandbox.SandboxResourceSpec{Kodo: &kodoResource})
+		pathsToList = append(pathsToList, kodoResource.MountPath)
+	}
+
+	if len(resources) == 0 {
+		log.Fatal("请设置 GITHUB_TOKEN 或 QINIU_SANDBOX_KODO_BUCKET 以启用至少一种资源")
 	}
 
 	params := sandbox.CreateParams{
 		TemplateID: "base",
-		Resources: &[]sandbox.SandboxResourceSpec{
-			{GitRepository: &repoResource},
-		},
+		Resources:  &resources,
 	}
+
+	log.Printf("Creating sandbox with %d resource(s)...", len(resources))
 
 	// 创建并等待沙箱就绪
 	sb, info, err := client.CreateAndWait(ctx, params)
@@ -68,13 +135,100 @@ func main() {
 
 	log.Printf("Sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
 
-	// 列出已挂载的仓库内容，验证资源已就位
-	listCmd := "ls -la /workspace/repo | head -20"
-	log.Printf("Executing command in sandbox:\n$ %s\n", listCmd)
+	// 列出已挂载的资源内容，验证资源已就位
+	for _, path := range pathsToList {
+		listCmd := "ls -la " + path + " | head -20"
+		runAndLog(ctx, sb, listCmd)
+	}
 
-	result, err := sb.Commands().Run(ctx, listCmd)
+	writeContent := "sandbox resource write test\n" +
+		"time: " + time.Now().UTC().Format(time.RFC3339Nano) + "\n" +
+		"sandbox: " + sb.ID() + "\n"
+
+	if githubToken != "" {
+		gitFilePath := path.Join(gitMountPath, gitTestFile)
+		writeCmd := writeFileCommand(gitFilePath, writeContent+"resource: git\n")
+		runAndLog(ctx, sb, writeCmd)
+		runAndLog(ctx, sb, "git -C "+shellQuote(gitMountPath)+" status --short "+shellQuote(gitTestFile))
+	}
+
+	if kodoBucket != "" && kodoWriteTest {
+		kodoFilePath := path.Join(kodoMountPath, kodoTestFile)
+		runAndLog(ctx, sb, writeFileCommand(kodoFilePath, writeContent+"resource: kodo\n"))
+	}
+
+	if githubToken != "" && gitPushTest {
+		pushURL, err := githubTokenPushURL(repoURL)
+		if err != nil {
+			log.Fatalf("Failed to build Git push URL: %v", err)
+		}
+		runAndLog(ctx, sb, gitCommitAndPushCommand(gitMountPath, gitTestFile, gitCommitName, gitCommitEmail, gitCommitMessage, gitPushBranch, pushURL), sandbox.WithTimeout(2*time.Minute), sandbox.WithEnvs(map[string]string{
+			"GITHUB_TOKEN":        githubToken,
+			"GIT_TERMINAL_PROMPT": "0",
+		}))
+	}
+}
+
+func loadEnvFileIfExists(paths ...string) {
+	for _, p := range paths {
+		file, err := os.Open(p)
+		if err != nil {
+			continue
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			key, value, ok := strings.Cut(line, "=")
+			if !ok {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			value = strings.Trim(value, `"'`)
+			value = strings.TrimSpace(value)
+			if key != "" {
+				_ = os.Setenv(key, value)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			log.Fatalf("Failed to read .env file %s: %v", p, err)
+		}
+		log.Printf("Loaded environment from %s", p)
+		return
+	}
+}
+
+func envDefault(key, fallback string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func envBool(key string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "":
+		return fallback
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func runAndLog(ctx context.Context, sb *sandbox.Sandbox, cmd string, opts ...sandbox.CommandOption) {
+	log.Printf("Executing command in sandbox:\n$ %s\n", cmd)
+
+	result, err := sb.Commands().Run(ctx, cmd, opts...)
 	if err != nil {
-		log.Fatalf("Failed to run command: %v", err)
+		panic(fmt.Sprintf("Failed to run command: %v", err))
 	}
 
 	log.Printf("ExitCode: %d\n", result.ExitCode)
@@ -84,4 +238,61 @@ func main() {
 	if result.Stderr != "" {
 		log.Printf("Stderr:\n%s\n", result.Stderr)
 	}
+	if result.ExitCode != 0 {
+		panic(fmt.Sprintf("command failed with exit code %d", result.ExitCode))
+	}
+}
+
+func githubTokenPushURL(repoURL string) (string, error) {
+	repoURL = strings.TrimSpace(repoURL)
+	repoURL = strings.TrimSuffix(repoURL, "/")
+	switch {
+	case strings.HasPrefix(repoURL, "https://"):
+		return "https://x-access-token:${GITHUB_TOKEN}@" + strings.TrimPrefix(repoURL, "https://"), nil
+	case strings.HasPrefix(repoURL, "http://"):
+		return "https://x-access-token:${GITHUB_TOKEN}@" + strings.TrimPrefix(repoURL, "http://"), nil
+	case strings.HasPrefix(repoURL, "git@github.com:"):
+		return "https://x-access-token:${GITHUB_TOKEN}@github.com/" + strings.TrimPrefix(repoURL, "git@github.com:"), nil
+	default:
+		return "", fmt.Errorf("unsupported GitHub repository URL: %s", repoURL)
+	}
+}
+
+func gitCommitAndPushCommand(repoPath, filePath, name, email, message, branch, pushURL string) string {
+	branchExpr := "branch=" + shellQuote(branch)
+	if branch == "" {
+		branchExpr = "branch=$(git -C " + shellQuote(repoPath) + " rev-parse --abbrev-ref HEAD)"
+	}
+	return strings.Join([]string{
+		"set -e",
+		branchExpr,
+		"test \"$branch\" != HEAD",
+		"git -C " + shellQuote(repoPath) + " config user.name " + shellQuote(name),
+		"git -C " + shellQuote(repoPath) + " config user.email " + shellQuote(email),
+		"git -C " + shellQuote(repoPath) + " remote set-url origin " + shellDoubleQuote(pushURL),
+		"git -C " + shellQuote(repoPath) + " add " + shellQuote(filePath),
+		"git -C " + shellQuote(repoPath) + " commit -m " + shellQuote(message),
+		"for attempt in 1 2 3; do git -C " + shellQuote(repoPath) + " push origin HEAD:\"$branch\" && break; if [ \"$attempt\" = 3 ]; then exit 1; fi; sleep $((attempt * 2)); done",
+	}, " && ")
+}
+
+func writeFileCommand(filePath, content string) string {
+	dir := path.Dir(filePath)
+	return strings.Join([]string{
+		"mkdir -p " + shellQuote(dir),
+		"printf %s " + shellQuote(content) + " > " + shellQuote(filePath),
+		"ls -la " + shellQuote(filePath),
+		"sed -n '1,20p' " + shellQuote(filePath),
+	}, " && ")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func shellDoubleQuote(s string) string {
+	const tokenPlaceholder = "__GITHUB_TOKEN_PLACEHOLDER__"
+	s = strings.ReplaceAll(s, "${GITHUB_TOKEN}", tokenPlaceholder)
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`, `$`, `\$`, "`", "\\`")
+	return `"` + strings.ReplaceAll(replacer.Replace(s), tokenPlaceholder, "${GITHUB_TOKEN}") + `"`
 }

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -31,146 +32,222 @@ func main() {
 
 	apiURL := strings.TrimSpace(os.Getenv("QINIU_SANDBOX_API_URL"))
 
-	// 演示用的 GitHub 仓库与 token，可通过环境变量覆盖。
-	repoURL := os.Getenv("QINIU_SANDBOX_GIT_REPO_URL")
-	if repoURL == "" {
-		repoURL = "https://github.com/qiniu/go-sdk.git"
-	}
-	githubToken := os.Getenv("GITHUB_TOKEN")
-	gitMountPath := "/workspace/repo"
-	gitPushTest := envBool("QINIU_SANDBOX_GIT_PUSH_TEST", false)
-	gitTestFile := os.Getenv("QINIU_SANDBOX_GIT_TEST_FILE")
-	if gitTestFile == "" {
-		gitTestFile = "sandbox-resource-write-test.txt"
-	}
-	gitCommitName := envDefault("QINIU_SANDBOX_GIT_COMMIT_NAME", "Sandbox Resource Demo")
-	gitCommitEmail := envDefault("QINIU_SANDBOX_GIT_COMMIT_EMAIL", "sandbox-resource-demo@example.com")
-	gitCommitMessage := envDefault("QINIU_SANDBOX_GIT_COMMIT_MESSAGE", "test: update sandbox resource write file")
-	gitPushBranch := os.Getenv("QINIU_SANDBOX_GIT_PUSH_BRANCH")
-
-	// 演示用的 Kodo 存储桶资源。设置 QINIU_SANDBOX_KODO_BUCKET 后启用。
-	kodoBucket := os.Getenv("QINIU_SANDBOX_KODO_BUCKET")
-	kodoMountPath := os.Getenv("QINIU_SANDBOX_KODO_MOUNT_PATH")
-	if kodoMountPath == "" {
-		kodoMountPath = "/workspace/kodo"
-	}
-	kodoPrefix := os.Getenv("QINIU_SANDBOX_KODO_PREFIX")
-	kodoReadOnly := os.Getenv("QINIU_SANDBOX_KODO_READ_ONLY")
-	kodoAccessKey := os.Getenv("QINIU_ACCESS_KEY")
-	kodoSecretKey := os.Getenv("QINIU_SECRET_KEY")
-	kodoWriteTest := envBool("QINIU_SANDBOX_KODO_WRITE_TEST", true)
-	kodoTestFile := os.Getenv("QINIU_SANDBOX_KODO_TEST_FILE")
-	if kodoTestFile == "" {
-		kodoTestFile = "sandbox-resource-write-test.txt"
-	}
-
 	ctx := context.Background()
+	gitConfig := loadGitResourceConfig()
+	kodoConfig := loadKodoResourceConfig()
 
-	var credentials *auth.Credentials
-	if kodoBucket != "" {
-		if kodoAccessKey == "" || kodoSecretKey == "" {
-			log.Fatal("启用 Kodo 资源时请设置 QINIU_ACCESS_KEY 和 QINIU_SECRET_KEY 环境变量")
-		}
-		credentials = auth.New(kodoAccessKey, kodoSecretKey)
+	if !gitConfig.Enabled() && !kodoConfig.Enabled() {
+		log.Fatal("请设置 GITHUB_TOKEN 和 QINIU_SANDBOX_GIT_REPO_URL，或设置 QINIU_SANDBOX_KODO_BUCKET，以启用至少一种资源")
 	}
 
-	// 初始化客户端
-	client, err := sandbox.NewClient(&sandbox.Config{
-		APIKey:      apiKey,
-		Credentials: credentials,
-		Endpoint:    apiURL,
-	})
-	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+	var failures []error
+	if gitConfig.Enabled() {
+		client, err := sandbox.NewClient(&sandbox.Config{
+			APIKey:   apiKey,
+			Endpoint: apiURL,
+		})
+		if err != nil {
+			failures = append(failures, fmt.Errorf("create Git resource client: %w", err))
+		} else if err := runGitResourceExample(ctx, client, gitConfig); err != nil {
+			failures = append(failures, fmt.Errorf("Git resource example: %w", err))
+			log.Printf("Git resource example failed: %v", err)
+		}
 	}
 
-	resources := make([]sandbox.SandboxResourceSpec, 0, 2)
-	pathsToList := make([]string, 0, 2)
-
-	if githubToken != "" {
-		// 通过 Resources 在沙箱启动前由平台拉取 GitHub 仓库快照并挂载到 /workspace/repo。
-		repoResource := sandbox.GitRepositoryResource{
-			Type:               sandbox.GitRepositoryTypeGithub,
-			URL:                repoURL,
-			MountPath:          gitMountPath,
-			AuthorizationToken: &githubToken,
+	if kodoConfig.Enabled() {
+		if kodoConfig.AccessKey == "" || kodoConfig.SecretKey == "" {
+			failures = append(failures, errors.New("启用 Kodo 资源时请设置 QINIU_ACCESS_KEY 和 QINIU_SECRET_KEY 环境变量"))
+		} else {
+			client, err := sandbox.NewClient(&sandbox.Config{
+				APIKey:      apiKey,
+				Credentials: auth.New(kodoConfig.AccessKey, kodoConfig.SecretKey),
+				Endpoint:    apiURL,
+			})
+			if err != nil {
+				failures = append(failures, fmt.Errorf("create Kodo resource client: %w", err))
+			} else if err := runKodoResourceExample(ctx, client, kodoConfig); err != nil {
+				failures = append(failures, fmt.Errorf("Kodo resource example: %w", err))
+				log.Printf("Kodo resource example failed: %v", err)
+			}
 		}
-		resources = append(resources, sandbox.SandboxResourceSpec{GitRepository: &repoResource})
-		pathsToList = append(pathsToList, repoResource.MountPath)
 	}
 
-	if kodoBucket != "" {
-		// 通过 Resources 在沙箱启动前将 Kodo 存储桶挂载到指定路径。
-		kodoResource := sandbox.KodoResource{
-			Bucket:    kodoBucket,
-			MountPath: kodoMountPath,
-		}
-		if kodoPrefix != "" {
-			kodoResource.Prefix = &kodoPrefix
-		}
-		if kodoReadOnly != "" {
-			readOnly := kodoReadOnly == "true"
-			kodoResource.ReadOnly = &readOnly
-		}
-		resources = append(resources, sandbox.SandboxResourceSpec{Kodo: &kodoResource})
-		pathsToList = append(pathsToList, kodoResource.MountPath)
+	if len(failures) > 0 {
+		log.Fatal(errors.Join(failures...))
 	}
+}
 
-	if len(resources) == 0 {
-		log.Fatal("请设置 GITHUB_TOKEN 或 QINIU_SANDBOX_KODO_BUCKET 以启用至少一种资源")
+type gitResourceConfig struct {
+	RepoURL       string
+	Token         string
+	MountPath     string
+	PushTest      bool
+	TestFile      string
+	CommitName    string
+	CommitEmail   string
+	CommitMessage string
+	PushBranch    string
+}
+
+func loadGitResourceConfig() gitResourceConfig {
+	return gitResourceConfig{
+		RepoURL:       os.Getenv("QINIU_SANDBOX_GIT_REPO_URL"),
+		Token:         os.Getenv("GITHUB_TOKEN"),
+		MountPath:     "/workspace/repo",
+		PushTest:      envBool("QINIU_SANDBOX_GIT_PUSH_TEST", false),
+		TestFile:      envDefault("QINIU_SANDBOX_GIT_TEST_FILE", "sandbox-resource-write-test.txt"),
+		CommitName:    envDefault("QINIU_SANDBOX_GIT_COMMIT_NAME", "Sandbox Resource Demo"),
+		CommitEmail:   envDefault("QINIU_SANDBOX_GIT_COMMIT_EMAIL", "sandbox-resource-demo@example.com"),
+		CommitMessage: envDefault("QINIU_SANDBOX_GIT_COMMIT_MESSAGE", "test: update sandbox resource write file"),
+		PushBranch:    os.Getenv("QINIU_SANDBOX_GIT_PUSH_BRANCH"),
 	}
+}
 
-	params := sandbox.CreateParams{
+func (c gitResourceConfig) Enabled() bool {
+	return c.Token != "" && c.RepoURL != ""
+}
+
+func runGitResourceExample(ctx context.Context, client *sandbox.Client, cfg gitResourceConfig) error {
+	resource := sandbox.GitRepositoryResource{
+		Type:               sandbox.GitRepositoryTypeGithub,
+		URL:                cfg.RepoURL,
+		MountPath:          cfg.MountPath,
+		AuthorizationToken: &cfg.Token,
+	}
+	resources := []sandbox.SandboxResourceSpec{{GitRepository: &resource}}
+
+	log.Println("Creating sandbox with Git repository resource...")
+	sb, info, err := client.CreateAndWait(ctx, sandbox.CreateParams{
 		TemplateID: "base",
 		Resources:  &resources,
-	}
-
-	log.Printf("Creating sandbox with %d resource(s)...", len(resources))
-
-	// 创建并等待沙箱就绪
-	sb, info, err := client.CreateAndWait(ctx, params)
+	})
 	if err != nil {
-		log.Fatalf("Failed to create sandbox: %v", err)
+		return err
 	}
 	defer func() {
-		log.Println("Killing sandbox...")
+		log.Println("Killing Git resource sandbox...")
 		_ = sb.Kill(ctx)
 	}()
 
-	log.Printf("Sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
+	log.Printf("Git resource sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
+	if err := runAndLog(ctx, sb, "ls -la "+shellQuote(cfg.MountPath)+" | head -20"); err != nil {
+		return err
+	}
 
-	// 列出已挂载的资源内容，验证资源已就位
-	for _, path := range pathsToList {
-		listCmd := "ls -la " + path + " | head -20"
-		runAndLog(ctx, sb, listCmd)
+	var pushURL string
+	if cfg.PushTest {
+		pushURL, err = githubTokenPushURL(cfg.RepoURL)
+		if err != nil {
+			return err
+		}
+		if err := runAndLog(ctx, sb, gitSyncBranchCommand(cfg.MountPath, cfg.PushBranch, pushURL), sandbox.WithTimeout(2*time.Minute), sandbox.WithEnvs(map[string]string{
+			"GITHUB_TOKEN":        cfg.Token,
+			"GIT_TERMINAL_PROMPT": "0",
+		})); err != nil {
+			return err
+		}
 	}
 
 	writeContent := "sandbox resource write test\n" +
 		"time: " + time.Now().UTC().Format(time.RFC3339Nano) + "\n" +
 		"sandbox: " + sb.ID() + "\n"
-
-	if githubToken != "" {
-		gitFilePath := path.Join(gitMountPath, gitTestFile)
-		writeCmd := writeFileCommand(gitFilePath, writeContent+"resource: git\n")
-		runAndLog(ctx, sb, writeCmd)
-		runAndLog(ctx, sb, "git -C "+shellQuote(gitMountPath)+" status --short "+shellQuote(gitTestFile))
+	gitFilePath := path.Join(cfg.MountPath, cfg.TestFile)
+	if err := runAndLog(ctx, sb, writeFileCommand(gitFilePath, writeContent+"resource: git\n")); err != nil {
+		return err
+	}
+	if err := runAndLog(ctx, sb, "git -C "+shellQuote(cfg.MountPath)+" status --short "+shellQuote(cfg.TestFile)); err != nil {
+		return err
 	}
 
-	if kodoBucket != "" && kodoWriteTest {
-		kodoFilePath := path.Join(kodoMountPath, kodoTestFile)
-		runAndLog(ctx, sb, writeFileCommand(kodoFilePath, writeContent+"resource: kodo\n"))
-	}
-
-	if githubToken != "" && gitPushTest {
-		pushURL, err := githubTokenPushURL(repoURL)
-		if err != nil {
-			log.Fatalf("Failed to build Git push URL: %v", err)
-		}
-		runAndLog(ctx, sb, gitCommitAndPushCommand(gitMountPath, gitTestFile, gitCommitName, gitCommitEmail, gitCommitMessage, gitPushBranch, pushURL), sandbox.WithTimeout(2*time.Minute), sandbox.WithEnvs(map[string]string{
-			"GITHUB_TOKEN":        githubToken,
+	if cfg.PushTest {
+		if err := runAndLog(ctx, sb, gitCommitAndPushCommand(cfg.MountPath, cfg.TestFile, cfg.CommitName, cfg.CommitEmail, cfg.CommitMessage, cfg.PushBranch), sandbox.WithTimeout(2*time.Minute), sandbox.WithEnvs(map[string]string{
+			"GITHUB_TOKEN":        cfg.Token,
 			"GIT_TERMINAL_PROMPT": "0",
-		}))
+		})); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+type kodoResourceConfig struct {
+	Bucket    string
+	MountPath string
+	Prefix    string
+	ReadOnly  string
+	AccessKey string
+	SecretKey string
+	WriteTest bool
+	TestFile  string
+}
+
+func loadKodoResourceConfig() kodoResourceConfig {
+	return kodoResourceConfig{
+		Bucket:    os.Getenv("QINIU_SANDBOX_KODO_BUCKET"),
+		MountPath: envDefault("QINIU_SANDBOX_KODO_MOUNT_PATH", "/workspace/kodo"),
+		Prefix:    os.Getenv("QINIU_SANDBOX_KODO_PREFIX"),
+		ReadOnly:  os.Getenv("QINIU_SANDBOX_KODO_READ_ONLY"),
+		AccessKey: os.Getenv("QINIU_ACCESS_KEY"),
+		SecretKey: os.Getenv("QINIU_SECRET_KEY"),
+		WriteTest: envBool("QINIU_SANDBOX_KODO_WRITE_TEST", true),
+		TestFile:  envDefault("QINIU_SANDBOX_KODO_TEST_FILE", "sandbox-resource-write-test.txt"),
+	}
+}
+
+func (c kodoResourceConfig) Enabled() bool {
+	return c.Bucket != ""
+}
+
+func runKodoResourceExample(ctx context.Context, client *sandbox.Client, cfg kodoResourceConfig) error {
+	resource := sandbox.KodoResource{
+		Bucket:    cfg.Bucket,
+		MountPath: cfg.MountPath,
+	}
+	if cfg.Prefix != "" {
+		resource.Prefix = &cfg.Prefix
+	}
+	if cfg.ReadOnly != "" {
+		readOnly := strings.EqualFold(cfg.ReadOnly, "true")
+		resource.ReadOnly = &readOnly
+	}
+	resources := []sandbox.SandboxResourceSpec{{Kodo: &resource}}
+
+	log.Println("Creating sandbox with Kodo bucket resource...")
+	sb, info, err := client.CreateAndWait(ctx, sandbox.CreateParams{
+		TemplateID: "base",
+		Resources:  &resources,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		log.Println("Killing Kodo resource sandbox...")
+		_ = sb.Kill(ctx)
+	}()
+
+	log.Printf("Kodo resource sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
+	if err := runAndLog(ctx, sb, "ls -la "+shellQuote(cfg.MountPath)+" | head -20"); err != nil {
+		return err
+	}
+
+	if cfg.WriteTest {
+		if cfg.ReadOnlyEnabled() {
+			log.Println("Skipping Kodo write test because QINIU_SANDBOX_KODO_READ_ONLY=true")
+			return nil
+		}
+		writeContent := "sandbox resource write test\n" +
+			"time: " + time.Now().UTC().Format(time.RFC3339Nano) + "\n" +
+			"sandbox: " + sb.ID() + "\n" +
+			"resource: kodo\n"
+		if err := runAndLog(ctx, sb, writeFileCommand(path.Join(cfg.MountPath, cfg.TestFile), writeContent)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c kodoResourceConfig) ReadOnlyEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(c.ReadOnly), "true")
 }
 
 func loadEnvFileIfExists(paths ...string) {
@@ -195,7 +272,7 @@ func loadEnvFileIfExists(paths ...string) {
 			value = strings.TrimSpace(value)
 			value = strings.Trim(value, `"'`)
 			value = strings.TrimSpace(value)
-			if key != "" {
+			if _, exists := os.LookupEnv(key); key != "" && !exists {
 				_ = os.Setenv(key, value)
 			}
 		}
@@ -227,12 +304,12 @@ func envBool(key string, fallback bool) bool {
 	}
 }
 
-func runAndLog(ctx context.Context, sb *sandbox.Sandbox, cmd string, opts ...sandbox.CommandOption) {
+func runAndLog(ctx context.Context, sb *sandbox.Sandbox, cmd string, opts ...sandbox.CommandOption) error {
 	log.Printf("Executing command in sandbox:\n$ %s\n", cmd)
 
 	result, err := sb.Commands().Run(ctx, cmd, opts...)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to run command: %v", err))
+		return fmt.Errorf("run command: %w", err)
 	}
 
 	log.Printf("ExitCode: %d\n", result.ExitCode)
@@ -243,8 +320,9 @@ func runAndLog(ctx context.Context, sb *sandbox.Sandbox, cmd string, opts ...san
 		log.Printf("Stderr:\n%s\n", result.Stderr)
 	}
 	if result.ExitCode != 0 {
-		panic(fmt.Sprintf("command failed with exit code %d", result.ExitCode))
+		return fmt.Errorf("command failed with exit code %d", result.ExitCode)
 	}
+	return nil
 }
 
 func githubTokenPushURL(repoURL string) (string, error) {
@@ -262,7 +340,23 @@ func githubTokenPushURL(repoURL string) (string, error) {
 	}
 }
 
-func gitCommitAndPushCommand(repoPath, filePath, name, email, message, branch, pushURL string) string {
+func gitSyncBranchCommand(repoPath, branch, pushURL string) string {
+	branchExpr := "branch=" + shellQuote(branch)
+	if branch == "" {
+		branchExpr = "branch=$(git -C " + shellQuote(repoPath) + " rev-parse --abbrev-ref HEAD)"
+	}
+	return strings.Join([]string{
+		"set -e",
+		branchExpr,
+		"test \"$branch\" != HEAD",
+		"git -C " + shellQuote(repoPath) + " remote set-url origin " + shellDoubleQuote(pushURL),
+		"git -C " + shellQuote(repoPath) + " fetch origin \"$branch\"",
+		"git -C " + shellQuote(repoPath) + " checkout \"$branch\"",
+		"git -C " + shellQuote(repoPath) + " reset --hard \"origin/$branch\"",
+	}, " && ")
+}
+
+func gitCommitAndPushCommand(repoPath, filePath, name, email, message, branch string) string {
 	branchExpr := "branch=" + shellQuote(branch)
 	if branch == "" {
 		branchExpr = "branch=$(git -C " + shellQuote(repoPath) + " rev-parse --abbrev-ref HEAD)"
@@ -273,7 +367,6 @@ func gitCommitAndPushCommand(repoPath, filePath, name, email, message, branch, p
 		"test \"$branch\" != HEAD",
 		"git -C " + shellQuote(repoPath) + " config user.name " + shellQuote(name),
 		"git -C " + shellQuote(repoPath) + " config user.email " + shellQuote(email),
-		"git -C " + shellQuote(repoPath) + " remote set-url origin " + shellDoubleQuote(pushURL),
 		"git -C " + shellQuote(repoPath) + " add " + shellQuote(filePath),
 		"git -C " + shellQuote(repoPath) + " commit -m " + shellQuote(message),
 		"for attempt in 1 2 3; do git -C " + shellQuote(repoPath) + " push origin HEAD:\"$branch\" && break; if [ \"$attempt\" = 3 ]; then exit 1; fi; sleep $((attempt * 2)); done",

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/qiniu/go-sdk/v7/auth"
 	"github.com/qiniu/go-sdk/v7/sandbox"
 )
 
@@ -65,10 +66,19 @@ func main() {
 
 	ctx := context.Background()
 
+	var credentials *auth.Credentials
+	if kodoBucket != "" {
+		if kodoAccessKey == "" || kodoSecretKey == "" {
+			log.Fatal("启用 Kodo 资源时请设置 QINIU_ACCESS_KEY 和 QINIU_SECRET_KEY 环境变量")
+		}
+		credentials = auth.New(kodoAccessKey, kodoSecretKey)
+	}
+
 	// 初始化客户端
 	client, err := sandbox.NewClient(&sandbox.Config{
-		APIKey:   apiKey,
-		Endpoint: apiURL,
+		APIKey:      apiKey,
+		Credentials: credentials,
+		Endpoint:    apiURL,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
@@ -101,12 +111,6 @@ func main() {
 		if kodoReadOnly != "" {
 			readOnly := kodoReadOnly == "true"
 			kodoResource.ReadOnly = &readOnly
-		}
-		if kodoAccessKey != "" {
-			kodoResource.AccessKey = &kodoAccessKey
-		}
-		if kodoSecretKey != "" {
-			kodoResource.SecretKey = &kodoSecretKey
 		}
 		resources = append(resources, sandbox.SandboxResourceSpec{Kodo: &kodoResource})
 		pathsToList = append(pathsToList, kodoResource.MountPath)

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -387,7 +387,7 @@ func gitCommitAndPushCommand(repoPath, filePath, name, email, message, branch st
 		"git -C " + shellQuote(repoPath) + " config user.email " + shellQuote(email),
 		"git -C " + shellQuote(repoPath) + " add " + shellQuote(filePath),
 		"git -C " + shellQuote(repoPath) + " commit -m " + shellQuote(message),
-		"for attempt in 1 2 3; do git -C " + shellQuote(repoPath) + " push origin HEAD:\"$branch\" && break; if [ \"$attempt\" = 3 ]; then exit 1; fi; sleep $((attempt * 2)); done",
+		"for attempt in 1 2 3; do if git -C " + shellQuote(repoPath) + " push origin HEAD:\"$branch\"; then break; fi; if [ \"$attempt\" = 3 ]; then exit 1; fi; sleep $((attempt * 2)); done",
 	}, " && ")
 }
 

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -123,7 +123,9 @@ func runGitResourceExample(ctx context.Context, client *sandbox.Client, cfg gitR
 	}
 	defer func() {
 		log.Println("Killing Git resource sandbox...")
-		_ = sb.Kill(ctx)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = sb.Kill(cleanupCtx)
 	}()
 
 	log.Printf("Git resource sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
@@ -222,7 +224,9 @@ func runKodoResourceExample(ctx context.Context, client *sandbox.Client, cfg kod
 	}
 	defer func() {
 		log.Println("Killing Kodo resource sandbox...")
-		_ = sb.Kill(ctx)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = sb.Kill(cleanupCtx)
 	}()
 
 	log.Printf("Kodo resource sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -16,12 +16,6 @@ import (
 )
 
 func main() {
-	defer func() {
-		if r := recover(); r != nil {
-			log.Fatalf("%v", r)
-		}
-	}()
-
 	loadEnvFileIfExists("examples/sandbox_resources/.env", ".env")
 
 	// 确保设置了环境变量 QINIU_API_KEY
@@ -34,7 +28,10 @@ func main() {
 
 	ctx := context.Background()
 	gitConfig := loadGitResourceConfig()
-	kodoConfig := loadKodoResourceConfig()
+	kodoConfig, err := loadKodoResourceConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if !gitConfig.Enabled() && !kodoConfig.Enabled() {
 		log.Fatal("请设置 GITHUB_TOKEN 和 QINIU_SANDBOX_GIT_REPO_URL，或设置 QINIU_SANDBOX_KODO_BUCKET，以启用至少一种资源")
@@ -174,24 +171,28 @@ type kodoResourceConfig struct {
 	Bucket    string
 	MountPath string
 	Prefix    string
-	ReadOnly  string
+	ReadOnly  *bool
 	AccessKey string
 	SecretKey string
 	WriteTest bool
 	TestFile  string
 }
 
-func loadKodoResourceConfig() kodoResourceConfig {
+func loadKodoResourceConfig() (kodoResourceConfig, error) {
+	readOnly, err := optionalEnvBool("QINIU_SANDBOX_KODO_READ_ONLY")
+	if err != nil {
+		return kodoResourceConfig{}, err
+	}
 	return kodoResourceConfig{
 		Bucket:    os.Getenv("QINIU_SANDBOX_KODO_BUCKET"),
 		MountPath: envDefault("QINIU_SANDBOX_KODO_MOUNT_PATH", "/workspace/kodo"),
 		Prefix:    os.Getenv("QINIU_SANDBOX_KODO_PREFIX"),
-		ReadOnly:  os.Getenv("QINIU_SANDBOX_KODO_READ_ONLY"),
+		ReadOnly:  readOnly,
 		AccessKey: os.Getenv("QINIU_ACCESS_KEY"),
 		SecretKey: os.Getenv("QINIU_SECRET_KEY"),
 		WriteTest: envBool("QINIU_SANDBOX_KODO_WRITE_TEST", true),
 		TestFile:  envDefault("QINIU_SANDBOX_KODO_TEST_FILE", "sandbox-resource-write-test.txt"),
-	}
+	}, nil
 }
 
 func (c kodoResourceConfig) Enabled() bool {
@@ -206,9 +207,8 @@ func runKodoResourceExample(ctx context.Context, client *sandbox.Client, cfg kod
 	if cfg.Prefix != "" {
 		resource.Prefix = &cfg.Prefix
 	}
-	if cfg.ReadOnly != "" {
-		readOnly := strings.EqualFold(cfg.ReadOnly, "true")
-		resource.ReadOnly = &readOnly
+	if cfg.ReadOnly != nil {
+		resource.ReadOnly = cfg.ReadOnly
 	}
 	resources := []sandbox.SandboxResourceSpec{{Kodo: &resource}}
 
@@ -247,7 +247,7 @@ func runKodoResourceExample(ctx context.Context, client *sandbox.Client, cfg kod
 }
 
 func (c kodoResourceConfig) ReadOnlyEnabled() bool {
-	return strings.EqualFold(strings.TrimSpace(c.ReadOnly), "true")
+	return c.ReadOnly != nil && *c.ReadOnly
 }
 
 func loadEnvFileIfExists(paths ...string) {
@@ -256,7 +256,6 @@ func loadEnvFileIfExists(paths ...string) {
 		if err != nil {
 			continue
 		}
-		defer file.Close()
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
@@ -275,6 +274,9 @@ func loadEnvFileIfExists(paths ...string) {
 			if _, exists := os.LookupEnv(key); key != "" && !exists {
 				_ = os.Setenv(key, value)
 			}
+		}
+		if err := file.Close(); err != nil {
+			log.Fatalf("Failed to close .env file %s: %v", p, err)
 		}
 		if err := scanner.Err(); err != nil {
 			log.Fatalf("Failed to read .env file %s: %v", p, err)
@@ -301,6 +303,22 @@ func envBool(key string, fallback bool) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func optionalEnvBool(key string) (*bool, error) {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "":
+		return nil, nil
+	case "1", "true", "yes", "on":
+		v := true
+		return &v, nil
+	case "0", "false", "no", "off":
+		v := false
+		return &v, nil
+	default:
+		return nil, fmt.Errorf("%s must be one of 1, true, yes, on, 0, false, no, or off", key)
 	}
 }
 

--- a/examples/sandbox_resources/main.go
+++ b/examples/sandbox_resources/main.go
@@ -272,10 +272,13 @@ func loadEnvFileIfExists(paths ...string) {
 				continue
 			}
 			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
 			value = strings.TrimSpace(value)
 			value = strings.Trim(value, `"'`)
 			value = strings.TrimSpace(value)
-			if _, exists := os.LookupEnv(key); key != "" && !exists {
+			if _, exists := os.LookupEnv(key); !exists {
 				_ = os.Setenv(key, value)
 			}
 		}

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -413,6 +413,59 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreateWithKodoResource(t *testing.T) {
+	token := "create-token"
+	prefix := "datasets/"
+	readOnly := true
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			if body.Resources == nil || len(*body.Resources) != 1 {
+				t.Fatalf("expected one resource, got %#v", body.Resources)
+			}
+			kodo, err := (*body.Resources)[0].AsKodoResource()
+			if err != nil {
+				t.Fatalf("expected KodoResource, got error: %v", err)
+			}
+			if kodo.Type != apis.Kodo {
+				t.Errorf("expected resource type %q, got %q", apis.Kodo, kodo.Type)
+			}
+			if kodo.Bucket != "test-bucket" {
+				t.Errorf("expected bucket test-bucket, got %q", kodo.Bucket)
+			}
+			if kodo.MountPath != "/mnt/kodo" {
+				t.Errorf("expected mount path /mnt/kodo, got %q", kodo.MountPath)
+			}
+			if kodo.Prefix == nil || *kodo.Prefix != prefix {
+				t.Errorf("expected prefix %q, got %v", prefix, kodo.Prefix)
+			}
+			if kodo.ReadOnly == nil || *kodo.ReadOnly != readOnly {
+				t.Errorf("expected read_only %v, got %v", readOnly, kodo.ReadOnly)
+			}
+			return &apis.CreateSandboxResponse{
+				JSON201:      &apis.Sandbox{SandboxID: "sb-123", TemplateID: "tmpl-1", EnvdAccessToken: &token},
+				HTTPResponse: httpResponse(201),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.Create(context.Background(), CreateParams{
+		TemplateID: "tmpl-1",
+		Resources: &[]SandboxResourceSpec{
+			{
+				Kodo: &KodoResource{
+					Bucket:    "test-bucket",
+					MountPath: "/mnt/kodo",
+					Prefix:    &prefix,
+					ReadOnly:  &readOnly,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateWithoutToken(t *testing.T) {
 	// Create API 不返回 token，应通过 GetSandbox 补充
 	token := "fallback-token"

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/qiniu/go-sdk/v7/auth"
 	"github.com/qiniu/go-sdk/v7/reqid"
 	"github.com/qiniu/go-sdk/v7/sandbox/internal/apis"
 )
@@ -419,6 +421,19 @@ func TestCreateWithKodoResource(t *testing.T) {
 	readOnly := true
 	mock := &mockAPI{
 		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			if len(editors) != 1 {
+				t.Fatalf("expected one credentials editor, got %d", len(editors))
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://sandbox.example.com/sandboxes", nil)
+			if err != nil {
+				t.Fatalf("unexpected request error: %v", err)
+			}
+			if err := editors[0](ctx, req); err != nil {
+				t.Fatalf("unexpected credentials editor error: %v", err)
+			}
+			if got := req.Header.Get("Authorization"); !strings.HasPrefix(got, "Qiniu ") {
+				t.Fatalf("expected Qiniu Authorization header, got %q", got)
+			}
 			if body.Resources == nil || len(*body.Resources) != 1 {
 				t.Fatalf("expected one resource, got %#v", body.Resources)
 			}
@@ -448,6 +463,7 @@ func TestCreateWithKodoResource(t *testing.T) {
 		},
 	}
 	c := newTestClient(mock)
+	c.config.Credentials = auth.New("ak", "sk")
 	_, err := c.Create(context.Background(), CreateParams{
 		TemplateID: "tmpl-1",
 		Resources: &[]SandboxResourceSpec{

--- a/sandbox/envd_rpc_test.go
+++ b/sandbox/envd_rpc_test.go
@@ -256,7 +256,7 @@ func TestFilesystemGetInfo(t *testing.T) {
 					Type:          filesystem.FileType_FILE_TYPE_FILE,
 					Path:          "/tmp/test.txt",
 					Size:          256,
-					Mode:          0644,
+					Mode:          0o644,
 					Permissions:   "rw-r--r--",
 					Owner:         "user",
 					Group:         "user",
@@ -1314,7 +1314,7 @@ func TestEntryInfoFromProtoFull(t *testing.T) {
 		Type:          filesystem.FileType_FILE_TYPE_FILE,
 		Path:          "/home/user/link.txt",
 		Size:          512,
-		Mode:          0777,
+		Mode:          0o777,
 		Permissions:   "rwxrwxrwx",
 		Owner:         "root",
 		Group:         "root",
@@ -1338,7 +1338,7 @@ func TestEntryInfoFromProtoFull(t *testing.T) {
 	if info.Size != 512 {
 		t.Errorf("Size = %d", info.Size)
 	}
-	if info.Mode != 0777 {
+	if info.Mode != 0o777 {
 		t.Errorf("Mode = %o", info.Mode)
 	}
 	if info.Permissions != "rwxrwxrwx" {

--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -70,6 +70,11 @@ const (
 	ID InjectionByIDType = "id"
 )
 
+// Defines values for KodoResourceType.
+const (
+	Kodo KodoResourceType = "kodo"
+)
+
 // Defines values for LogLevel.
 const (
 	LogLevelDebug LogLevel = "debug"
@@ -279,7 +284,7 @@ type GeneralRegistryType string
 
 // GitRepositoryResource GitHub repository resource mounted into the sandbox.
 // The platform materializes a cached snapshot of the repository for mounting.
-// The first snapshot is cloned from the repository default branch HEAD, and later sandboxes may reuse that cached snapshot without refreshing it to the latest HEAD.
+// The first snapshot is cloned from the repository default branch HEAD. Subsequent sandboxes reuse the cached snapshot, and the platform refreshes it to the latest default-branch HEAD on a best-effort schedule: a soft TTL triggers a background refresh (the triggering request keeps using the stale snapshot, but later requests that arrive while the refresh is in flight wait for it to complete), and a hard TTL forces the next request to block on a synchronous refresh.
 type GitRepositoryResource struct {
 	// AuthorizationToken GitHub token used to access this repository. All GitHub repository resources in a single sandbox must currently use the same token.
 	AuthorizationToken *string `json:"authorization_token,omitempty"`
@@ -290,7 +295,7 @@ type GitRepositoryResource struct {
 	// Type Resource type identifier
 	Type GitRepositoryResourceType `json:"type"`
 
-	// URL GitHub repository URL in HTTPS or SSH form, for example https://github.com/owner/repo.git or git@github.com:owner/repo.git
+	// URL GitHub repository URL in HTTPS form, or GitHub SSH-style form git@github.com:owner/repo.git. The platform normalizes the value to HTTPS.
 	URL string `json:"url"`
 }
 
@@ -358,6 +363,35 @@ type InjectionRule struct {
 	// UpdatedAt Timestamp when the injection rule was last updated
 	UpdatedAt time.Time `json:"updatedAt"`
 }
+
+// KodoResource Kodo bucket resource mounted into the sandbox via NFS.
+// The platform creates an NFS-backed proxy that maps the Kodo bucket to a local path inside the sandbox.
+// Credentials (access_key/secret_key) are never exposed inside the sandbox.
+type KodoResource struct {
+	// AccessKey Kodo access key ID
+	AccessKey *string `json:"access_key,omitempty"`
+
+	// Bucket Kodo bucket name
+	Bucket string `json:"bucket"`
+
+	// MountPath Absolute path where the bucket contents should appear inside the sandbox
+	MountPath string `json:"mount_path"`
+
+	// Prefix Optional subdirectory (key prefix) within the bucket. Only the contents under this prefix are exposed. If omitted, the whole bucket root is mounted.
+	Prefix *string `json:"prefix,omitempty"`
+
+	// ReadOnly Whether the mount is read-only. Automatically set to true when AK/SK lacks write permission. Can also be set explicitly.
+	ReadOnly *bool `json:"read_only,omitempty"`
+
+	// SecretKey Kodo secret access key
+	SecretKey *string `json:"secret_key,omitempty"`
+
+	// Type Resource type identifier
+	Type KodoResourceType `json:"type"`
+}
+
+// KodoResourceType Resource type identifier
+type KodoResourceType string
 
 // ListedSandbox defines model for ListedSandbox.
 type ListedSandbox struct {
@@ -756,6 +790,9 @@ type TemplateBuild struct {
 
 	// MemoryMB Memory for the sandbox in MiB
 	MemoryMB MemoryMB `json:"memoryMB"`
+
+	// ObjectStorageBytes Total bytes used in object storage for this build
+	ObjectStorageBytes *int64 `json:"objectStorageBytes,omitempty"`
 
 	// Status Status of the template build
 	Status TemplateBuildStatus `json:"status"`
@@ -1776,6 +1813,34 @@ func (t *SandboxResource) MergeGitRepositoryResource(v GitRepositoryResource) er
 	return err
 }
 
+// AsKodoResource returns the union data inside the SandboxResource as a KodoResource
+func (t SandboxResource) AsKodoResource() (KodoResource, error) {
+	var body KodoResource
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromKodoResource overwrites any union data inside the SandboxResource as the provided KodoResource
+func (t *SandboxResource) FromKodoResource(v KodoResource) error {
+	v.Type = "kodo"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeKodoResource performs a merge with any union data inside the SandboxResource, using the provided KodoResource
+func (t *SandboxResource) MergeKodoResource(v KodoResource) error {
+	v.Type = "kodo"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t SandboxResource) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1792,6 +1857,8 @@ func (t SandboxResource) ValueByDiscriminator() (interface{}, error) {
 	switch discriminator {
 	case "github_repository":
 		return t.AsGitRepositoryResource()
+	case "kodo":
+		return t.AsKodoResource()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}

--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -367,10 +367,8 @@ type InjectionRule struct {
 // KodoResource Kodo bucket resource mounted into the sandbox via NFS.
 // The platform creates an NFS-backed proxy that maps the Kodo bucket to a local path inside the sandbox.
 // Credentials (access_key/secret_key) are never exposed inside the sandbox.
+// Note: Kodo resource is only supported when creating a sandbox with Qiniu AKSK authentication. API key authentication is not supported.
 type KodoResource struct {
-	// AccessKey Kodo access key ID
-	AccessKey *string `json:"access_key,omitempty"`
-
 	// Bucket Kodo bucket name
 	Bucket string `json:"bucket"`
 
@@ -382,9 +380,6 @@ type KodoResource struct {
 
 	// ReadOnly Whether the mount is read-only. Automatically set to true when AK/SK lacks write permission. Can also be set explicitly.
 	ReadOnly *bool `json:"read_only,omitempty"`
-
-	// SecretKey Kodo secret access key
-	SecretKey *string `json:"secret_key,omitempty"`
 
 	// Type Resource type identifier
 	Type KodoResourceType `json:"type"`

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -108,7 +108,15 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.api.CreateSandboxWithResponse(ctx, apiParams)
+	var editors []apis.RequestEditorFn
+	if params.hasKodoResource() {
+		cred, err := c.GetCredentialsOption()
+		if err != nil {
+			return nil, err
+		}
+		editors = append(editors, cred)
+	}
+	resp, err := c.api.CreateSandboxWithResponse(ctx, apiParams, editors...)
 	if err != nil {
 		return nil, err
 	}

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -115,7 +115,7 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 			return nil, err
 		}
 		if cred == nil {
-			return nil, fmt.Errorf("Kodo resource requires Qiniu AK/SK credentials, please configure them in sandbox.Config")
+			return nil, fmt.Errorf("kodo resource requires Qiniu AK/SK credentials, please configure them in sandbox.Config")
 		}
 		editors = append(editors, cred)
 	}

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -114,9 +114,10 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 		if err != nil {
 			return nil, err
 		}
-		if cred != nil {
-			editors = append(editors, cred)
+		if cred == nil {
+			return nil, fmt.Errorf("Kodo resource requires Qiniu AK/SK credentials, please configure them in sandbox.Config")
 		}
+		editors = append(editors, cred)
 	}
 	resp, err := c.api.CreateSandboxWithResponse(ctx, apiParams, editors...)
 	if err != nil {

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -114,7 +114,9 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 		if err != nil {
 			return nil, err
 		}
-		editors = append(editors, cred)
+		if cred != nil {
+			editors = append(editors, cred)
+		}
 	}
 	resp, err := c.api.CreateSandboxWithResponse(ctx, apiParams, editors...)
 	if err != nil {

--- a/sandbox/types.go
+++ b/sandbox/types.go
@@ -72,6 +72,18 @@ type CreateParams struct {
 	Resources *[]SandboxResourceSpec
 }
 
+func (p CreateParams) hasKodoResource() bool {
+	if p.Resources == nil {
+		return false
+	}
+	for _, resource := range *p.Resources {
+		if resource.Kodo != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // ConnectParams 连接沙箱的请求参数。
 type ConnectParams struct {
 	// Timeout 超时时间（秒）。

--- a/sandbox/types_resource.go
+++ b/sandbox/types_resource.go
@@ -37,10 +37,35 @@ type GitRepositoryResource struct {
 	AuthorizationToken *string
 }
 
+// KodoResource Kodo 存储桶资源，沙箱启动前由平台通过 NFS 代理挂载到指定路径。
+// access_key 和 secret_key 仅用于服务端挂载，凭证不会暴露给沙箱内进程。
+type KodoResource struct {
+	// Bucket Kodo 存储桶名称（必填）。
+	Bucket string
+
+	// MountPath 存储桶内容在沙箱内的绝对挂载路径（必填）。
+	MountPath string
+
+	// Prefix 存储桶内可选的对象名前缀；不设置时挂载整个存储桶根目录。
+	Prefix *string
+
+	// ReadOnly 是否以只读方式挂载；当 AK/SK 缺少写权限时服务端也会自动只读。
+	ReadOnly *bool
+
+	// AccessKey Kodo AccessKey，可选。
+	AccessKey *string
+
+	// SecretKey Kodo SecretKey，可选。
+	SecretKey *string
+}
+
 // SandboxResourceSpec 沙箱资源规约（discriminated union），各字段互斥，只能设置一个。
 type SandboxResourceSpec struct {
 	// GitRepository GitHub 仓库资源。
 	GitRepository *GitRepositoryResource
+
+	// Kodo Kodo 存储桶资源。
+	Kodo *KodoResource
 }
 
 // ---------------------------------------------------------------------------
@@ -49,6 +74,20 @@ type SandboxResourceSpec struct {
 
 func sandboxResourceSpecToAPI(spec SandboxResourceSpec) (apis.SandboxResource, error) {
 	var r apis.SandboxResource
+	count := 0
+	if spec.GitRepository != nil {
+		count++
+	}
+	if spec.Kodo != nil {
+		count++
+	}
+	if count == 0 {
+		return r, fmt.Errorf("SandboxResourceSpec: exactly one resource type must be set (GitRepository or Kodo), got none")
+	}
+	if count > 1 {
+		return r, fmt.Errorf("SandboxResourceSpec: exactly one resource type must be set, but got %d", count)
+	}
+
 	switch {
 	case spec.GitRepository != nil:
 		if spec.GitRepository.Type == "" {
@@ -71,8 +110,25 @@ func sandboxResourceSpecToAPI(spec SandboxResourceSpec) (apis.SandboxResource, e
 		}); err != nil {
 			return r, err
 		}
+	case spec.Kodo != nil:
+		if spec.Kodo.Bucket == "" {
+			return r, fmt.Errorf("KodoResource.Bucket must be set")
+		}
+		if spec.Kodo.MountPath == "" {
+			return r, fmt.Errorf("KodoResource.MountPath must be set")
+		}
+		if err := r.FromKodoResource(apis.KodoResource{
+			Bucket:    spec.Kodo.Bucket,
+			MountPath: spec.Kodo.MountPath,
+			Prefix:    spec.Kodo.Prefix,
+			ReadOnly:  spec.Kodo.ReadOnly,
+			AccessKey: spec.Kodo.AccessKey,
+			SecretKey: spec.Kodo.SecretKey,
+		}); err != nil {
+			return r, err
+		}
 	default:
-		return r, fmt.Errorf("SandboxResourceSpec: exactly one resource type must be set (GitRepository), got none")
+		panic("unreachable")
 	}
 	return r, nil
 }

--- a/sandbox/types_resource.go
+++ b/sandbox/types_resource.go
@@ -38,7 +38,7 @@ type GitRepositoryResource struct {
 }
 
 // KodoResource Kodo 存储桶资源，沙箱启动前由平台通过 NFS 代理挂载到指定路径。
-// access_key 和 secret_key 仅用于服务端挂载，凭证不会暴露给沙箱内进程。
+// 使用 Kodo 资源创建沙箱时，客户端必须可用 Qiniu AK/SK 凭证。
 type KodoResource struct {
 	// Bucket Kodo 存储桶名称（必填）。
 	Bucket string
@@ -51,12 +51,6 @@ type KodoResource struct {
 
 	// ReadOnly 是否以只读方式挂载；当 AK/SK 缺少写权限时服务端也会自动只读。
 	ReadOnly *bool
-
-	// AccessKey Kodo AccessKey，可选。
-	AccessKey *string
-
-	// SecretKey Kodo SecretKey，可选。
-	SecretKey *string
 }
 
 // SandboxResourceSpec 沙箱资源规约（discriminated union），各字段互斥，只能设置一个。
@@ -122,8 +116,6 @@ func sandboxResourceSpecToAPI(spec SandboxResourceSpec) (apis.SandboxResource, e
 			MountPath: spec.Kodo.MountPath,
 			Prefix:    spec.Kodo.Prefix,
 			ReadOnly:  spec.Kodo.ReadOnly,
-			AccessKey: spec.Kodo.AccessKey,
-			SecretKey: spec.Kodo.SecretKey,
 		}); err != nil {
 			return r, err
 		}

--- a/sandbox/types_resource.go
+++ b/sandbox/types_resource.go
@@ -120,7 +120,7 @@ func sandboxResourceSpecToAPI(spec SandboxResourceSpec) (apis.SandboxResource, e
 			return r, err
 		}
 	default:
-		panic("unreachable")
+		return r, fmt.Errorf("SandboxResourceSpec: unsupported resource type")
 	}
 	return r, nil
 }

--- a/sandbox/types_resource_test.go
+++ b/sandbox/types_resource_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestSandboxResourceSpecToAPIKodoResource(t *testing.T) {
-	accessKey := "ak"
-	secretKey := "sk"
 	prefix := "datasets/"
 	readOnly := true
 
@@ -19,8 +17,6 @@ func TestSandboxResourceSpecToAPIKodoResource(t *testing.T) {
 			MountPath: "/mnt/kodo",
 			Prefix:    &prefix,
 			ReadOnly:  &readOnly,
-			AccessKey: &accessKey,
-			SecretKey: &secretKey,
 		},
 	})
 	if err != nil {
@@ -46,11 +42,11 @@ func TestSandboxResourceSpecToAPIKodoResource(t *testing.T) {
 	if got["read_only"] != true {
 		t.Errorf("expected read_only true, got %v", got["read_only"])
 	}
-	if got["access_key"] != "ak" {
-		t.Errorf("expected access_key ak, got %v", got["access_key"])
+	if _, ok := got["access_key"]; ok {
+		t.Errorf("expected access_key omitted, got %v", got["access_key"])
 	}
-	if got["secret_key"] != "sk" {
-		t.Errorf("expected secret_key sk, got %v", got["secret_key"])
+	if _, ok := got["secret_key"]; ok {
+		t.Errorf("expected secret_key omitted, got %v", got["secret_key"])
 	}
 }
 

--- a/sandbox/types_resource_test.go
+++ b/sandbox/types_resource_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+
+package sandbox
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSandboxResourceSpecToAPIKodoResource(t *testing.T) {
+	accessKey := "ak"
+	secretKey := "sk"
+	prefix := "datasets/"
+	readOnly := true
+
+	resource, err := sandboxResourceSpecToAPI(SandboxResourceSpec{
+		Kodo: &KodoResource{
+			Bucket:    "test-bucket",
+			MountPath: "/mnt/kodo",
+			Prefix:    &prefix,
+			ReadOnly:  &readOnly,
+			AccessKey: &accessKey,
+			SecretKey: &secretKey,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(mustMarshalJSON(t, resource), &got); err != nil {
+		t.Fatalf("unexpected JSON error: %v", err)
+	}
+	if got["type"] != "kodo" {
+		t.Errorf("expected type kodo, got %v", got["type"])
+	}
+	if got["bucket"] != "test-bucket" {
+		t.Errorf("expected bucket test-bucket, got %v", got["bucket"])
+	}
+	if got["mount_path"] != "/mnt/kodo" {
+		t.Errorf("expected mount_path /mnt/kodo, got %v", got["mount_path"])
+	}
+	if got["prefix"] != "datasets/" {
+		t.Errorf("expected prefix datasets/, got %v", got["prefix"])
+	}
+	if got["read_only"] != true {
+		t.Errorf("expected read_only true, got %v", got["read_only"])
+	}
+	if got["access_key"] != "ak" {
+		t.Errorf("expected access_key ak, got %v", got["access_key"])
+	}
+	if got["secret_key"] != "sk" {
+		t.Errorf("expected secret_key sk, got %v", got["secret_key"])
+	}
+}
+
+func TestSandboxResourceSpecToAPIKodoResourceValidation(t *testing.T) {
+	_, err := sandboxResourceSpecToAPI(SandboxResourceSpec{
+		Kodo: &KodoResource{MountPath: "/mnt/kodo"},
+	})
+	if err == nil {
+		t.Fatal("expected error when KodoResource.Bucket is empty")
+	}
+
+	_, err = sandboxResourceSpecToAPI(SandboxResourceSpec{
+		Kodo: &KodoResource{Bucket: "test-bucket"},
+	})
+	if err == nil {
+		t.Fatal("expected error when KodoResource.MountPath is empty")
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("unexpected JSON marshal error: %v", err)
+	}
+	return data
+}


### PR DESCRIPTION
## 概要
- 同步最新 sandbox OpenAPI 规范并重新生成 sandbox API 类型。
- 新增 SDK 层 `KodoResource` 支持，创建包含 Kodo 资源的 sandbox 时使用 Qiniu AK/SK 签名。
- 优化 `examples/sandbox_resources`：Git 与 Kodo 资源拆分为独立示例流程，支持同一次运行分别验证，新增 `.env.example`。
- 补充 Kodo resource 转换和创建请求认证路径的单元测试。

## 处理的 Review 反馈
- 移除示例中的 `panic/recover` 控制流，命令执行改为返回 error 并统一汇总。
- 避免在 `.env` 文件查找循环中使用 `defer file.Close()`。
- SDK 转换函数不再在默认分支 panic，改为返回错误。
- Kodo `read_only` 环境变量支持 `1/true/yes/on` 与 `0/false/no/off`，并在只读挂载时跳过写入测试。
- Git 示例命令补齐 shell quoting，并在 push 前同步远端分支，方便重复运行。

## 验证
- `go test -tags=unit ./sandbox -count=1`
- `go build ./sandbox/...`
- `go build ./examples/sandbox_resources`
- `git diff --check`
- 在 `examples/sandbox_resources` 目录执行 `go run main.go`，验证 Git resource 与 Kodo resource 创建、挂载和写入流程。
