### PR TITLE
chore: release v7.26.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 7.26.13
+
+* 新增
+  * sandbox: 支持创建沙箱时挂载 Kodo bucket 资源
+* 完善
+  * examples: 优化 sandbox resources 示例，支持 Git 仓库与 Kodo bucket 资源独立验证，并提供环境变量示例
+
 ## 7.26.12
 
 * 修复

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.12
+require github.com/qiniu/go-sdk/v7 v7.26.13
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.12"
+const Version = "7.26.13"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## 发布内容

- 更新 SDK 版本号到 v7.26.13
- 补充 CHANGELOG v7.26.13，记录 sandbox Kodo bucket resource 支持和示例完善
- 同步 README 中的 go.mod 示例版本

## 验证

- `git diff --check`
- `go test ./conf`
- `go build ./examples/sandbox_resources`

## release-check

| 位置 | 期望 | 状态 |
|------|------|------|
| `conf/conf.go` | `const Version = "7.26.13"` | 通过 |
| `CHANGELOG.md` | `## 7.26.13` | 通过 |
| `README.md` | `require github.com/qiniu/go-sdk/v7 v7.26.13` | 通过 |