### PR TITLE
feat(sandbox): support scoped request injections

### DIFF
--- a/examples/sandbox_injection_rules/main.go
+++ b/examples/sandbox_injection_rules/main.go
@@ -45,12 +45,20 @@ func main() {
 	headers := map[string]string{
 		"Authorization": "Bearer real_token",
 	}
+	ifHeaders := map[string]string{
+		"X-Injection-Scope": "demo",
+	}
+	ifQueries := map[string]string{
+		"inject": "true",
+	}
 	rule, err := c.CreateInjectionRule(ctx, sandbox.CreateInjectionRuleParams{
 		Name: "example-rule",
 		Injection: sandbox.InjectionSpec{
 			HTTP: &sandbox.HTTPInjection{
-				BaseURL: "https://httpbin.org",
-				Headers: &headers,
+				BaseURL:   "https://httpbin.org",
+				Headers:   &headers,
+				IfHeaders: &ifHeaders,
+				IfQueries: &ifQueries,
 			},
 		},
 	})
@@ -83,6 +91,12 @@ func main() {
 		if detail.Injection.HTTP.Headers != nil {
 			fmt.Printf("  注入 Headers: %v\n", *detail.Injection.HTTP.Headers)
 		}
+		if detail.Injection.HTTP.IfHeaders != nil {
+			fmt.Printf("  Header 匹配条件: %v\n", *detail.Injection.HTTP.IfHeaders)
+		}
+		if detail.Injection.HTTP.IfQueries != nil {
+			fmt.Printf("  Query 匹配条件: %v\n", *detail.Injection.HTTP.IfQueries)
+		}
 	}
 
 	// 3. 更新注入规则
@@ -92,12 +106,20 @@ func main() {
 		"Authorization": "Bearer updated_token",
 		"X-Custom":      "custom-value",
 	}
+	newIfHeaders := map[string]string{
+		"X-Injection-Scope": "updated-demo",
+	}
+	newIfQueries := map[string]string{
+		"inject": "updated",
+	}
 	updated, err := c.UpdateInjectionRule(ctx, ruleID, sandbox.UpdateInjectionRuleParams{
 		Name: &newName,
 		Injection: &sandbox.InjectionSpec{
 			HTTP: &sandbox.HTTPInjection{
-				BaseURL: "https://httpbin.org",
-				Headers: &newHeaders,
+				BaseURL:   "https://httpbin.org",
+				Headers:   &newHeaders,
+				IfHeaders: &newIfHeaders,
+				IfQueries: &newIfQueries,
 			},
 		},
 	})
@@ -137,7 +159,7 @@ func main() {
 	fmt.Printf("沙箱已创建: ID=%s, 状态=%s\n", sb.ID(), info.State)
 
 	// 在沙箱内验证注入规则生效
-	cmd := `curl -sSL -X GET "https://httpbin.org/bearer" -H "accept: application/json" -H "Authorization: Bearer fake_token"`
+	cmd := `curl -sSL -X GET "https://httpbin.org/bearer?inject=updated" -H "accept: application/json" -H "Authorization: Bearer fake_token" -H "X-Injection-Scope: updated-demo"`
 	fmt.Printf("\n执行命令:\n$ %s\n", cmd)
 	result, err := sb.Commands().Run(ctx, cmd)
 	if err != nil {

--- a/examples/sandbox_request_injections/main.go
+++ b/examples/sandbox_request_injections/main.go
@@ -38,6 +38,12 @@ func main() {
 	headers := map[string]string{
 		"Authorization": "Bearer real_xxx",
 	}
+	ifHeaders := map[string]string{
+		"X-Injection-Scope": "demo",
+	}
+	ifQueries := map[string]string{
+		"inject": "true",
+	}
 
 	// 准备创建参数（HTTP 自定义注入）
 	params := sandbox.CreateParams{
@@ -45,8 +51,10 @@ func main() {
 		Injections: &[]sandbox.SandboxInjectionSpec{
 			{
 				HTTP: &sandbox.HTTPInjection{
-					BaseURL: "https://httpbin.org",
-					Headers: &headers,
+					BaseURL:   "https://httpbin.org",
+					Headers:   &headers,
+					IfHeaders: &ifHeaders,
+					IfQueries: &ifQueries,
 				},
 			},
 		},
@@ -88,8 +96,9 @@ func main() {
 	log.Printf("Sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
 
 	// 在沙箱内执行使用假 APIKEY 的请求
-	// 沙箱内的程序完全感觉不到外部注入，实际上外层将其拦截并替换为了真实的 Key
-	fakeTokenCmd := `curl -sSL -X GET "https://httpbin.org/bearer" -H "accept: application/json" -H "Authorization: Bearer fake_xxx"`
+	// 沙箱内的程序完全感觉不到外部注入；只有请求同时满足 IfHeaders / IfQueries
+	// 匹配条件时，外层才会拦截并替换为真实的 Key。
+	fakeTokenCmd := `curl -sSL -X GET "https://httpbin.org/bearer?inject=true" -H "accept: application/json" -H "Authorization: Bearer fake_xxx" -H "X-Injection-Scope: demo"`
 	log.Printf("Executing command in sandbox:\n$ %s\n", fakeTokenCmd)
 
 	result, err := sb.Commands().Run(ctx, fakeTokenCmd)

--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -143,8 +143,14 @@ type AnthropicInjection struct {
 	// APIKey API key for Anthropic API
 	APIKey *string `json:"api_key,omitempty"`
 
-	// BaseURL Optional base URL. If not specified, uses api.anthropic.com
+	// BaseURL Optional base URL. If not specified, uses api.anthropic.com. The host is matched exactly. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
 	BaseURL *string `json:"base_url,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
 
 	// Type Injection type identifier
 	Type AnthropicInjectionType `json:"type"`
@@ -257,8 +263,14 @@ type GeminiInjection struct {
 	// APIKey API key for Google Gemini API
 	APIKey *string `json:"api_key,omitempty"`
 
-	// BaseURL Optional base URL. If not specified, uses generativelanguage.googleapis.com
+	// BaseURL Optional base URL. If not specified, uses generativelanguage.googleapis.com. The host is matched exactly. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
 	BaseURL *string `json:"base_url,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
 
 	// Type Injection type identifier
 	Type GeminiInjectionType `json:"type"`
@@ -305,6 +317,15 @@ type GitRepositoryResourceType string
 // GithubInjection GitHub credential used by the platform to validate and clone repositories before sandbox startup, and to authenticate matching HTTPS requests to github.com and api.github.com while the sandbox is running.
 // The token is not exposed inside the sandbox as plaintext.
 type GithubInjection struct {
+	// BaseURL Optional base URL. If not specified, the platform applies the token to github.com and api.github.com. When specified, the host must be github.com or api.github.com. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
+	BaseURL *string `json:"base_url,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
+
 	// Token GitHub token with access to all requested repositories
 	Token *string `json:"token,omitempty"`
 
@@ -317,12 +338,18 @@ type GithubInjectionType string
 
 // HTTPInjection Custom HTTP injection with base URL and headers
 type HTTPInjection struct {
-	// BaseURL Base URL for matching HTTPS requests. The domain part is used for host matching.
+	// BaseURL Base URL for matching HTTPS requests. The host is matched exactly. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
 	// Default scheme is https if not specified.
 	BaseURL string `json:"base_url"`
 
 	// Headers HTTP headers to inject or overwrite on matching HTTPS requests.
 	Headers *map[string]string `json:"headers,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
 
 	// Type Injection type identifier
 	Type HTTPInjectionType `json:"type"`
@@ -493,8 +520,14 @@ type OpenaiInjection struct {
 	// APIKey API key for OpenAI-compatible APIs
 	APIKey *string `json:"api_key,omitempty"`
 
-	// BaseURL Optional base URL. If not specified, uses api.openai.com
+	// BaseURL Optional base URL. If not specified, uses api.openai.com. The host is matched exactly. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
 	BaseURL *string `json:"base_url,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
 
 	// Type Injection type identifier
 	Type OpenaiInjectionType `json:"type"`
@@ -511,8 +544,14 @@ type QiniuInjection struct {
 	// APIKey API key for Qiniu AI API
 	APIKey *string `json:"api_key,omitempty"`
 
-	// BaseURL Optional base URL. If not specified, uses api.qnaigc.com
+	// BaseURL Optional base URL. If not specified, uses api.qnaigc.com. The host is matched exactly. When a path is present, it matches the normalized request path exactly; a trailing `*` enables normalized string-prefix matching.
 	BaseURL *string `json:"base_url,omitempty"`
+
+	// IfHeaders Optional HTTP request headers that must already be present with exact values before this injection matches. Header names are matched case-insensitively; repeated headers compare only their first value. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set request headers.
+	IfHeaders *map[string]string `json:"if_headers,omitempty"`
+
+	// IfQueries Optional query parameters that must already be present with exact values before this injection matches. Query parameter names are case-sensitive. These conditions only scope request matching and are not an authorization boundary; sandbox processes can set query parameters.
+	IfQueries *map[string]string `json:"if_queries,omitempty"`
 
 	// Type Injection type identifier
 	Type QiniuInjectionType `json:"type"`

--- a/sandbox/types_injection_rule.go
+++ b/sandbox/types_injection_rule.go
@@ -17,8 +17,15 @@ type OpenAIInjection struct {
 	// APIKey API 密钥，可选。
 	APIKey *string
 
-	// BaseURL 可选 base URL，未指定时使用 api.openai.com。
+	// BaseURL 可选 base URL，未指定时使用 api.openai.com。host 精确匹配；
+	// path 存在时精确匹配规范化路径，尾部 * 表示前缀匹配。
 	BaseURL *string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
 }
 
 // AnthropicInjection Anthropic API 注入配置。自动设置 x-api-key 头。
@@ -27,8 +34,15 @@ type AnthropicInjection struct {
 	// APIKey API 密钥，可选。
 	APIKey *string
 
-	// BaseURL 可选 base URL，未指定时使用 api.anthropic.com。
+	// BaseURL 可选 base URL，未指定时使用 api.anthropic.com。host 精确匹配；
+	// path 存在时精确匹配规范化路径，尾部 * 表示前缀匹配。
 	BaseURL *string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
 }
 
 // GeminiInjection Google Gemini API 注入配置。自动设置 x-goog-api-key 头。
@@ -38,7 +52,14 @@ type GeminiInjection struct {
 	APIKey *string
 
 	// BaseURL 可选 base URL，未指定时使用 generativelanguage.googleapis.com。
+	// host 精确匹配；path 存在时精确匹配规范化路径，尾部 * 表示前缀匹配。
 	BaseURL *string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
 }
 
 // QiniuInjection 七牛 AI API 注入配置。七牛网关同时兼容 OpenAI 和 Anthropic 协议，
@@ -48,26 +69,49 @@ type QiniuInjection struct {
 	// APIKey API 密钥。
 	APIKey *string
 
-	// BaseURL 可选 base URL，未指定时使用 api.qnaigc.com。
+	// BaseURL 可选 base URL，未指定时使用 api.qnaigc.com。host 精确匹配；
+	// path 存在时精确匹配规范化路径，尾部 * 表示前缀匹配。
 	BaseURL *string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
 }
 
 // GithubInjection GitHub 凭证注入。平台用此凭证克隆并校验仓库，且在沙箱运行期间为
 // 匹配 github.com / api.github.com 的 HTTPS 请求自动注入认证；token 不会以明文形式
 // 暴露到沙箱内。
 type GithubInjection struct {
+	// BaseURL 可选 base URL，未指定时平台会匹配 github.com 和 api.github.com。
+	// 指定时 host 必须为 github.com 或 api.github.com。
+	BaseURL *string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
+
 	// Token GitHub token，对所有请求的仓库具备访问权限。
 	Token *string
 }
 
 // HTTPInjection 自定义 HTTP 注入配置。
 type HTTPInjection struct {
-	// BaseURL 匹配 HTTPS 请求的 base URL。域名部分用于 host 匹配。
-	// 若未指定 scheme 默认为 https。
+	// BaseURL 匹配 HTTPS 请求的 base URL。host 精确匹配；path 存在时精确匹配
+	// 规范化路径，尾部 * 表示前缀匹配。若未指定 scheme 默认为 https。
 	BaseURL string
 
 	// Headers 需要注入或覆盖的 HTTP Headers，可选。
 	Headers *map[string]string
+
+	// IfHeaders 可选请求 Header 匹配条件，满足后才注入。
+	IfHeaders *map[string]string
+
+	// IfQueries 可选请求 query 匹配条件，满足后才注入。
+	IfQueries *map[string]string
 }
 
 // InjectionSpec 注入配置（discriminated union），各字段互斥，只能设置一个。
@@ -213,38 +257,51 @@ func injectionSpecToAPI(spec InjectionSpec) (apis.Injection, error) {
 	switch {
 	case spec.OpenAI != nil:
 		err = inj.FromOpenaiInjection(apis.OpenaiInjection{
-			APIKey:  spec.OpenAI.APIKey,
-			BaseURL: spec.OpenAI.BaseURL,
-			Type:    apis.Openai,
+			APIKey:    spec.OpenAI.APIKey,
+			BaseURL:   spec.OpenAI.BaseURL,
+			IfHeaders: spec.OpenAI.IfHeaders,
+			IfQueries: spec.OpenAI.IfQueries,
+			Type:      apis.Openai,
 		})
 	case spec.Anthropic != nil:
 		err = inj.FromAnthropicInjection(apis.AnthropicInjection{
-			APIKey:  spec.Anthropic.APIKey,
-			BaseURL: spec.Anthropic.BaseURL,
-			Type:    apis.Anthropic,
+			APIKey:    spec.Anthropic.APIKey,
+			BaseURL:   spec.Anthropic.BaseURL,
+			IfHeaders: spec.Anthropic.IfHeaders,
+			IfQueries: spec.Anthropic.IfQueries,
+			Type:      apis.Anthropic,
 		})
 	case spec.Gemini != nil:
 		err = inj.FromGeminiInjection(apis.GeminiInjection{
-			APIKey:  spec.Gemini.APIKey,
-			BaseURL: spec.Gemini.BaseURL,
-			Type:    apis.Gemini,
+			APIKey:    spec.Gemini.APIKey,
+			BaseURL:   spec.Gemini.BaseURL,
+			IfHeaders: spec.Gemini.IfHeaders,
+			IfQueries: spec.Gemini.IfQueries,
+			Type:      apis.Gemini,
 		})
 	case spec.Qiniu != nil:
 		err = inj.FromQiniuInjection(apis.QiniuInjection{
-			APIKey:  spec.Qiniu.APIKey,
-			BaseURL: spec.Qiniu.BaseURL,
-			Type:    apis.Qiniu,
+			APIKey:    spec.Qiniu.APIKey,
+			BaseURL:   spec.Qiniu.BaseURL,
+			IfHeaders: spec.Qiniu.IfHeaders,
+			IfQueries: spec.Qiniu.IfQueries,
+			Type:      apis.Qiniu,
 		})
 	case spec.Github != nil:
 		err = inj.FromGithubInjection(apis.GithubInjection{
-			Token: spec.Github.Token,
-			Type:  apis.Github,
+			BaseURL:   spec.Github.BaseURL,
+			IfHeaders: spec.Github.IfHeaders,
+			IfQueries: spec.Github.IfQueries,
+			Token:     spec.Github.Token,
+			Type:      apis.Github,
 		})
 	case spec.HTTP != nil:
 		err = inj.FromHTTPInjection(apis.HTTPInjection{
-			BaseURL: spec.HTTP.BaseURL,
-			Headers: spec.HTTP.Headers,
-			Type:    apis.HTTP,
+			BaseURL:   spec.HTTP.BaseURL,
+			Headers:   spec.HTTP.Headers,
+			IfHeaders: spec.HTTP.IfHeaders,
+			IfQueries: spec.HTTP.IfQueries,
+			Type:      apis.HTTP,
 		})
 	}
 	return inj, err
@@ -290,38 +347,51 @@ func sandboxInjectionSpecToAPI(spec SandboxInjectionSpec) (apis.SandboxInjection
 		})
 	case spec.OpenAI != nil:
 		err = si.FromOpenaiInjection(apis.OpenaiInjection{
-			APIKey:  spec.OpenAI.APIKey,
-			BaseURL: spec.OpenAI.BaseURL,
-			Type:    apis.Openai,
+			APIKey:    spec.OpenAI.APIKey,
+			BaseURL:   spec.OpenAI.BaseURL,
+			IfHeaders: spec.OpenAI.IfHeaders,
+			IfQueries: spec.OpenAI.IfQueries,
+			Type:      apis.Openai,
 		})
 	case spec.Anthropic != nil:
 		err = si.FromAnthropicInjection(apis.AnthropicInjection{
-			APIKey:  spec.Anthropic.APIKey,
-			BaseURL: spec.Anthropic.BaseURL,
-			Type:    apis.Anthropic,
+			APIKey:    spec.Anthropic.APIKey,
+			BaseURL:   spec.Anthropic.BaseURL,
+			IfHeaders: spec.Anthropic.IfHeaders,
+			IfQueries: spec.Anthropic.IfQueries,
+			Type:      apis.Anthropic,
 		})
 	case spec.Gemini != nil:
 		err = si.FromGeminiInjection(apis.GeminiInjection{
-			APIKey:  spec.Gemini.APIKey,
-			BaseURL: spec.Gemini.BaseURL,
-			Type:    apis.Gemini,
+			APIKey:    spec.Gemini.APIKey,
+			BaseURL:   spec.Gemini.BaseURL,
+			IfHeaders: spec.Gemini.IfHeaders,
+			IfQueries: spec.Gemini.IfQueries,
+			Type:      apis.Gemini,
 		})
 	case spec.Qiniu != nil:
 		err = si.FromQiniuInjection(apis.QiniuInjection{
-			APIKey:  spec.Qiniu.APIKey,
-			BaseURL: spec.Qiniu.BaseURL,
-			Type:    apis.Qiniu,
+			APIKey:    spec.Qiniu.APIKey,
+			BaseURL:   spec.Qiniu.BaseURL,
+			IfHeaders: spec.Qiniu.IfHeaders,
+			IfQueries: spec.Qiniu.IfQueries,
+			Type:      apis.Qiniu,
 		})
 	case spec.Github != nil:
 		err = si.FromGithubInjection(apis.GithubInjection{
-			Token: spec.Github.Token,
-			Type:  apis.Github,
+			BaseURL:   spec.Github.BaseURL,
+			IfHeaders: spec.Github.IfHeaders,
+			IfQueries: spec.Github.IfQueries,
+			Token:     spec.Github.Token,
+			Type:      apis.Github,
 		})
 	case spec.HTTP != nil:
 		err = si.FromHTTPInjection(apis.HTTPInjection{
-			BaseURL: spec.HTTP.BaseURL,
-			Headers: spec.HTTP.Headers,
-			Type:    apis.HTTP,
+			BaseURL:   spec.HTTP.BaseURL,
+			Headers:   spec.HTTP.Headers,
+			IfHeaders: spec.HTTP.IfHeaders,
+			IfQueries: spec.HTTP.IfQueries,
+			Type:      apis.HTTP,
 		})
 	}
 	return si, err
@@ -342,37 +412,37 @@ func injectionSpecFromAPI(inj apis.Injection) (InjectionSpec, error) {
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{OpenAI: &OpenAIInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
+		return InjectionSpec{OpenAI: &OpenAIInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
 	case string(apis.Anthropic):
 		v, err := inj.AsAnthropicInjection()
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{Anthropic: &AnthropicInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
+		return InjectionSpec{Anthropic: &AnthropicInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
 	case string(apis.Gemini):
 		v, err := inj.AsGeminiInjection()
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{Gemini: &GeminiInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
+		return InjectionSpec{Gemini: &GeminiInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
 	case string(apis.Qiniu):
 		v, err := inj.AsQiniuInjection()
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{Qiniu: &QiniuInjection{APIKey: v.APIKey, BaseURL: v.BaseURL}}, nil
+		return InjectionSpec{Qiniu: &QiniuInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
 	case string(apis.Github):
 		v, err := inj.AsGithubInjection()
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{Github: &GithubInjection{Token: v.Token}}, nil
+		return InjectionSpec{Github: &GithubInjection{BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries, Token: v.Token}}, nil
 	case string(apis.HTTP):
 		v, err := inj.AsHTTPInjection()
 		if err != nil {
 			return InjectionSpec{}, err
 		}
-		return InjectionSpec{HTTP: &HTTPInjection{BaseURL: v.BaseURL, Headers: v.Headers}}, nil
+		return InjectionSpec{HTTP: &HTTPInjection{BaseURL: v.BaseURL, Headers: v.Headers, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
 	default:
 		return InjectionSpec{}, fmt.Errorf("unknown injection type: %s", disc)
 	}

--- a/sandbox/types_injection_rule_test.go
+++ b/sandbox/types_injection_rule_test.go
@@ -1,0 +1,119 @@
+//go:build unit
+
+package sandbox
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/qiniu/go-sdk/v7/sandbox/internal/apis"
+)
+
+func TestInjectionSpecToAPIPreservesMatchConditions(t *testing.T) {
+	apiKey := "sk-test"
+	baseURL := "https://api.openai.com/v1/chat/*"
+	ifHeaders := map[string]string{"X-Use-Model": "gpt"}
+	ifQueries := map[string]string{"tenant": "demo"}
+
+	inj, err := injectionSpecToAPI(InjectionSpec{
+		OpenAI: &OpenAIInjection{
+			APIKey:    &apiKey,
+			BaseURL:   &baseURL,
+			IfHeaders: &ifHeaders,
+			IfQueries: &ifQueries,
+		},
+	})
+	if err != nil {
+		t.Fatalf("injectionSpecToAPI() error = %v", err)
+	}
+
+	got, err := inj.AsOpenaiInjection()
+	if err != nil {
+		t.Fatalf("AsOpenaiInjection() error = %v", err)
+	}
+	if got.APIKey == nil || *got.APIKey != apiKey {
+		t.Fatalf("APIKey = %v, want %q", got.APIKey, apiKey)
+	}
+	if got.BaseURL == nil || *got.BaseURL != baseURL {
+		t.Fatalf("BaseURL = %v, want %q", got.BaseURL, baseURL)
+	}
+	if !reflect.DeepEqual(got.IfHeaders, &ifHeaders) {
+		t.Fatalf("IfHeaders = %#v, want %#v", got.IfHeaders, &ifHeaders)
+	}
+	if !reflect.DeepEqual(got.IfQueries, &ifQueries) {
+		t.Fatalf("IfQueries = %#v, want %#v", got.IfQueries, &ifQueries)
+	}
+}
+
+func TestSandboxInjectionSpecToAPIPreservesGithubMatchConditions(t *testing.T) {
+	token := "ghp-test"
+	baseURL := "https://api.github.com/repos/qiniu/*"
+	ifHeaders := map[string]string{"X-GitHub-Api-Version": "2022-11-28"}
+	ifQueries := map[string]string{"per_page": "100"}
+
+	inj, err := sandboxInjectionSpecToAPI(SandboxInjectionSpec{
+		Github: &GithubInjection{
+			BaseURL:   &baseURL,
+			IfHeaders: &ifHeaders,
+			IfQueries: &ifQueries,
+			Token:     &token,
+		},
+	})
+	if err != nil {
+		t.Fatalf("sandboxInjectionSpecToAPI() error = %v", err)
+	}
+
+	got, err := inj.AsGithubInjection()
+	if err != nil {
+		t.Fatalf("AsGithubInjection() error = %v", err)
+	}
+	if got.BaseURL == nil || *got.BaseURL != baseURL {
+		t.Fatalf("BaseURL = %v, want %q", got.BaseURL, baseURL)
+	}
+	if !reflect.DeepEqual(got.IfHeaders, &ifHeaders) {
+		t.Fatalf("IfHeaders = %#v, want %#v", got.IfHeaders, &ifHeaders)
+	}
+	if !reflect.DeepEqual(got.IfQueries, &ifQueries) {
+		t.Fatalf("IfQueries = %#v, want %#v", got.IfQueries, &ifQueries)
+	}
+	if got.Token == nil || *got.Token != token {
+		t.Fatalf("Token = %v, want %q", got.Token, token)
+	}
+}
+
+func TestInjectionSpecFromAPIPreservesHTTPMatchConditions(t *testing.T) {
+	headers := map[string]string{"Authorization": "Bearer test"}
+	ifHeaders := map[string]string{"X-Env": "ci"}
+	ifQueries := map[string]string{"debug": "1"}
+
+	var inj apis.Injection
+	if err := inj.FromHTTPInjection(apis.HTTPInjection{
+		BaseURL:   "https://example.com/v1/*",
+		Headers:   &headers,
+		IfHeaders: &ifHeaders,
+		IfQueries: &ifQueries,
+		Type:      apis.HTTP,
+	}); err != nil {
+		t.Fatalf("FromHTTPInjection() error = %v", err)
+	}
+
+	got, err := injectionSpecFromAPI(inj)
+	if err != nil {
+		t.Fatalf("injectionSpecFromAPI() error = %v", err)
+	}
+	if got.HTTP == nil {
+		t.Fatal("HTTP injection is nil")
+	}
+	if got.HTTP.BaseURL != "https://example.com/v1/*" {
+		t.Fatalf("BaseURL = %q", got.HTTP.BaseURL)
+	}
+	if !reflect.DeepEqual(got.HTTP.Headers, &headers) {
+		t.Fatalf("Headers = %#v, want %#v", got.HTTP.Headers, &headers)
+	}
+	if !reflect.DeepEqual(got.HTTP.IfHeaders, &ifHeaders) {
+		t.Fatalf("IfHeaders = %#v, want %#v", got.HTTP.IfHeaders, &ifHeaders)
+	}
+	if !reflect.DeepEqual(got.HTTP.IfQueries, &ifQueries) {
+		t.Fatalf("IfQueries = %#v, want %#v", got.HTTP.IfQueries, &ifQueries)
+	}
+}


### PR DESCRIPTION
## Summary
- Sync api-specs submodule to qiniu/api-specs#20 and regenerate sandbox OpenAPI client code.
- Expose injection match conditions in the sandbox SDK layer: `IfHeaders` / `IfQueries`, plus `GithubInjection.BaseURL`.
- Update sandbox injection examples and add unit coverage to ensure match conditions survive SDK/API conversions.

## Validation
- `gofmt -s -l .`
- `make staticcheck`
- `make unittest`
- `go build ./examples/sandbox_request_injections ./examples/sandbox_injection_rules`
- `go build ./...`
