### PR TITLE
chore: release v7.26.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 7.26.14
+
+* 新增
+  * sandbox: 支持通过 Header 和 Query 条件限制请求注入规则的匹配范围
+  * sandbox: GitHub 凭证注入支持配置 base URL 匹配范围
+* 完善
+  * examples: 补充 sandbox 请求注入条件匹配示例
+
 ## 7.26.13
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.13
+require github.com/qiniu/go-sdk/v7 v7.26.14
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.13"
+const Version = "7.26.14"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## Summary
- Bump SDK version to `7.26.14`.
- Update README installation snippet to `v7.26.14`.
- Add CHANGELOG entry for sandbox scoped request injection support.

## Validation
- `grep -n "const Version" conf/conf.go`
- `grep -n "## 7.26.14" CHANGELOG.md`
- `grep -n "require github.com/qiniu/go-sdk/v7 v7.26.14" README.md`
- `git diff --check`
- `make staticcheck`
- `make unittest`
