### PR TITLE
storage: 兼容 CreatedAt 为空的 Bucket 信息响应，避免 time.Parse 失败导致 GetBucketInfo/BucketInfosInRegion 返回错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 7.26.15
+
+* 修复
+  * storage: 兼容 CreatedAt 为空的 Bucket 信息响应，避免 time.Parse 失败导致 GetBucketInfo/BucketInfosInRegion 返回错误
+
 ## 7.26.14
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.14
+require github.com/qiniu/go-sdk/v7 v7.26.15
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.14"
+const Version = "7.26.15"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"

--- a/storage/uc.go
+++ b/storage/uc.go
@@ -93,6 +93,7 @@ type BucketInfo struct {
 	Remark string
 
 	// 空间创建时间
+	// 当服务端未返回该字段时为零值，可通过 Ctime.IsZero() 判断
 	Ctime time.Time
 }
 
@@ -224,10 +225,18 @@ func (b *BucketInfo) TokenAntiLeechModeOn() bool {
 	return b.TokenAntiLeechMode == 1
 }
 
+// parseBucketCreatedAt 解析服务端返回的 CreatedAt 字符串；空字符串视为零值（无错误）
+func parseBucketCreatedAt(createdAt string) (time.Time, error) {
+	if createdAt == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, createdAt)
+}
+
 // GetBucketInfo 返回BucketInfo结构
 func (m *BucketManager) GetBucketInfo(bucketName string) (BucketInfo, error) {
 	toBucketInfo := func(bucketInfo *get_bucket_info.Response) (BucketInfo, error) {
-		ctime, err := time.Parse(time.RFC3339, bucketInfo.CreatedAt)
+		ctime, err := parseBucketCreatedAt(bucketInfo.CreatedAt)
 		if err != nil {
 			return BucketInfo{}, err
 		}
@@ -283,7 +292,7 @@ func (m *BucketManager) SetRemark(bucketName, remark string) error {
 // BucketInfosForRegion 获取指定区域的该用户的所有bucketInfo信息
 func (m *BucketManager) BucketInfosInRegion(region RegionID, statistics bool) (bucketInfos []BucketSummary, err error) {
 	toBucketInfo := func(bucketInfo *get_bucket_infos.BucketInfoV2) (BucketInfo, error) {
-		ctime, err := time.Parse(time.RFC3339, bucketInfo.CreatedAt)
+		ctime, err := parseBucketCreatedAt(bucketInfo.CreatedAt)
 		if err != nil {
 			return BucketInfo{}, err
 		}


### PR DESCRIPTION
## 背景

调用 `BucketManager.GetBucketInfo` 和 `BucketManager.BucketInfosInRegion` 时，如果服务端返回的 Bucket 响应中 `CreatedAt` 字段为空字符串，`time.Parse(time.RFC3339, "")` 会失败并返回 error，导致整个接口直接返回错误、无法获取 Bucket 其它信息。

## 处理方式

`storage/uc.go` 中两处 `toBucketInfo` 转换函数：当 `CreatedAt` 为空时，跳过 `time.Parse`，`ctime` 取零值 `time.Time{}`，正常返回 Bucket 其它信息；非空时按原逻辑解析，失败则返回错误。

```go
var ctime time.Time
if bucketInfo.CreatedAt != "" {
    var err error
    ctime, err = time.Parse(time.RFC3339, bucketInfo.CreatedAt)
    if err != nil {
        return BucketInfo{}, err
    }
}
```

## 影响范围

- 影响接口：`BucketManager.GetBucketInfo`、`BucketManager.BucketInfosInRegion`
- 影响包：`storage`（v1）
- 行为变化：原本因 `CreatedAt` 为空而整体失败的调用，现在能正常返回 Bucket 其它字段，仅 `Ctime` 字段为零值

## 兼容性

- 纯增量修复，向后兼容
- 不涉及 `storagev2` 和 api-specs

## 验证

- `gofmt -s -l .`：clean
- `go test -tags unit ./storage/`：PASS

## 提交链

- `033a92f` fix(storage): handle empty CreatedAt in bucket info responses
- `e014735` chore: release v7.26.15