### PR TITLE
fix(storagev2): 内置拓扑排序实现

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 7.26.16
+
+* 修复
+  * storagev2: 内置拓扑排序实现，避免 gammazero/toposort v0.1.1 与 v0.2.0 的模块版本冲突
+
 ## 7.26.15
 
 * 修复

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.15
+require github.com/qiniu/go-sdk/v7 v7.26.16
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.15"
+const Version = "7.26.16"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82
 	github.com/dave/jennifer v1.6.1
-	github.com/gammazero/toposort v0.1.1
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/gofrs/flock v0.8.1
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/gammazero/toposort v0.1.1 h1:OivGxsWxF3U3+U80VoLJ+f50HcPU1MIqE1JlKzoJ2Eg=
-github.com/gammazero/toposort v0.1.1/go.mod h1:H2cozTnNpMw0hg2VHAYsAxmkHXBYroNangj2NTBQDvw=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/internal/pkg/toposort/LICENSE
+++ b/internal/pkg/toposort/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Andrew J. Gillis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/pkg/toposort/toposort.go
+++ b/internal/pkg/toposort/toposort.go
@@ -1,0 +1,129 @@
+// Package toposort 提供有向无环图的拓扑排序。
+//
+// 本实现源自 github.com/gammazero/toposort v0.1.1，按 MIT 许可证分发，详见本目录的 LICENSE 文件。
+package toposort
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Edge represents a pair of vertexes.  Each vertex is an opaque type.
+type Edge [2]interface{}
+
+// Toposort performs a topological sort of the DAG defined by given edges.
+//
+// Takes a slice of Edge, where each element is a vertex pair representing an
+// edge in the graph.  Each pair can also be considered a dependency
+// relationship where Edge[0] must happen before Edge[1].  For a reversed
+// order, call ToposortR().
+//
+// To include a node that is not connected to the rest of the graph, include a
+// node with one nil vertex.  It can appear anywhere in the sorted output.
+//
+// Returns an ordered list of vertexes where each vertex occurs before any of
+// its destination vertexes.  An error is returned if a cycle is detected.
+func Toposort(edges []Edge) ([]interface{}, error) {
+	g, err := makeGraph(edges)
+	if err != nil {
+		return nil, err
+	}
+	sorted := make([]interface{}, 0, len(g))
+
+	// Create map of vertexes to incoming edge count, and set counts to 0
+	inDegree := make(map[interface{}]int, len(g))
+	for n := range g {
+		inDegree[n] = 0
+	}
+
+	// For each vertex u, get adjacent list
+	for _, adjacent := range g {
+		// For each vertex v adjacent to u
+		for _, v := range adjacent {
+			// Increment inDegree[v]
+			inDegree[v]++
+		}
+	}
+
+	// Make a list next consisting of all vertexes u such that inDegree[u] = 0
+	var next []interface{}
+	for u, deg := range inDegree {
+		if deg == 0 {
+			next = append(next, u)
+		}
+	}
+
+	// While next is not empty...
+	for len(next) > 0 {
+		// Pop a vertex from next and call it vertex u
+		u := next[len(next)-1]
+		next = next[:len(next)-1]
+
+		// Add u to the end sorted list
+		sorted = append(sorted, u)
+
+		// For each vertex v adjacent to sorted vertex u
+		for _, v := range g[u] {
+			// Decrement count of incoming edges
+			inDegree[v]--
+			// Enqueue nodes with no incoming edges
+			if inDegree[v] == 0 {
+				next = append(next, v)
+			}
+		}
+	}
+
+	// Check for cycle
+	if len(sorted) < len(g) {
+		var cycleNodes []string
+		for u, deg := range inDegree {
+			if deg != 0 {
+				cycleNodes = append(cycleNodes, fmt.Sprint(u))
+			}
+		}
+		return nil, fmt.Errorf("graph contains cycle in nodes %s", cycleNodes)
+	}
+
+	// Return the sorted vertex list
+	return sorted, nil
+}
+
+// ToposortR is the same as Toposort with the order of the output reversed.
+// This has the same effect as changing the vertex order of each edge.
+func ToposortR(edges []Edge) ([]interface{}, error) {
+	sorted, err := Toposort(edges)
+	if err != nil {
+		return nil, err
+	}
+	// Reverse slice
+	for i := len(sorted)/2 - 1; i >= 0; i-- {
+		opp := len(sorted) - 1 - i
+		sorted[i], sorted[opp] = sorted[opp], sorted[i]
+	}
+	return sorted, nil
+}
+
+// makeGraph creates a map of source node to destination nodes.  An edge with
+// only one vertex is added to the graph, if it is not already in the graph.
+func makeGraph(edges []Edge) (map[interface{}][]interface{}, error) {
+	graph := make(map[interface{}][]interface{}, len(edges)+1)
+	for i := range edges {
+		u, v := edges[i][0], edges[i][1]
+		if u == v {
+			return nil, errors.New("nodes in edge cannot be the same")
+		}
+		if u == nil {
+			// Add vertex only (empty destination list)
+			if _, ok := graph[v]; !ok {
+				graph[v] = nil
+			}
+		} else if v == nil {
+			if _, ok := graph[u]; !ok {
+				graph[u] = nil
+			}
+		} else {
+			graph[u] = append(graph[u], v)
+		}
+	}
+	return graph, nil
+}

--- a/internal/pkg/toposort/toposort_test.go
+++ b/internal/pkg/toposort/toposort_test.go
@@ -1,0 +1,89 @@
+//go:build unit
+
+package toposort
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToposort(t *testing.T) {
+	sorted, err := Toposort([]Edge{
+		{"A", "B"},
+		{"A", "C"},
+		{"B", "D"},
+		{"C", "D"},
+		{"E", nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBefore(t, sorted, "A", "B")
+	assertBefore(t, sorted, "A", "C")
+	assertBefore(t, sorted, "B", "D")
+	assertBefore(t, sorted, "C", "D")
+	if !contains(sorted, "E") {
+		t.Fatalf("missing unconnected vertex: %v", sorted)
+	}
+}
+
+func TestToposortDuplicateEdges(t *testing.T) {
+	sorted, err := Toposort([]Edge{
+		{"A", "B"},
+		{"A", "B"},
+		{"B", "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBefore(t, sorted, "A", "B")
+	assertBefore(t, sorted, "B", "C")
+}
+
+func TestToposortCycle(t *testing.T) {
+	_, err := Toposort([]Edge{
+		{"A", "B"},
+		{"B", "C"},
+		{"C", "A"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+}
+
+func TestToposortSelfEdge(t *testing.T) {
+	if _, err := Toposort([]Edge{{"A", "A"}}); err == nil {
+		t.Fatal("expected self-edge error")
+	}
+}
+
+func TestToposortR(t *testing.T) {
+	sorted, err := ToposortR([]Edge{{"A", "B"}, {"B", "C"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBefore(t, sorted, "C", "B")
+	assertBefore(t, sorted, "B", "A")
+}
+
+func assertBefore(t *testing.T, sorted []interface{}, first, second string) {
+	t.Helper()
+	firstIndex := indexOf(sorted, first)
+	secondIndex := indexOf(sorted, second)
+	if firstIndex == -1 || secondIndex == -1 || firstIndex >= secondIndex {
+		t.Fatalf("expected %q before %q in %v", first, second, sorted)
+	}
+}
+
+func contains(sorted []interface{}, expected string) bool {
+	return indexOf(sorted, expected) != -1
+}
+
+func indexOf(sorted []interface{}, expected string) int {
+	for index, vertex := range sorted {
+		if vertex == expected {
+			return index
+		}
+	}
+	return -1
+}

--- a/storagev2/objects/batch.go
+++ b/storagev2/objects/batch.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gammazero/toposort"
 	clientv1 "github.com/qiniu/go-sdk/v7/client"
 	internal_context "github.com/qiniu/go-sdk/v7/internal/context"
+	"github.com/qiniu/go-sdk/v7/internal/pkg/toposort"
 	"github.com/qiniu/go-sdk/v7/storagev2/apis"
 	"github.com/qiniu/go-sdk/v7/storagev2/apis/batch_ops"
 	"github.com/qiniu/go-sdk/v7/storagev2/apis/stat_object"


### PR DESCRIPTION
移除与 v0.2 API 不兼容的外部 toposort 依赖。对象批处理改用内置的 v0.1.1 实现，避免消费端模块版本冲突。

Fixes #195