### PR TITLE
feat(sandbox): update APIs from latest OpenAPI specs

### DIFF
--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,24 +22,27 @@ import (
 // mockAPI 实现 apis.ClientWithResponsesInterface 用于测试。
 // 每个方法字段可按测试设置；未设置的方法会 panic。
 type mockAPI struct {
-	createSandboxFn          func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error)
-	getSandboxFn             func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxResponse, error)
-	deleteSandboxFn          func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.DeleteSandboxResponse, error)
-	listSandboxesFn          func(ctx context.Context, params *apis.ListSandboxesParams, editors ...apis.RequestEditorFn) (*apis.ListSandboxesResponse, error)
-	listSandboxesV2Fn        func(ctx context.Context, params *apis.ListSandboxesV2Params, editors ...apis.RequestEditorFn) (*apis.ListSandboxesV2Response, error)
-	connectSandboxFn         func(ctx context.Context, sandboxID apis.SandboxID, body apis.ConnectSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.ConnectSandboxResponse, error)
-	updateSandboxTimeoutFn   func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxTimeoutJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxTimeoutResponse, error)
-	pauseSandboxFn           func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.PauseSandboxResponse, error)
-	getSandboxMetricsFn      func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxMetricsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxMetricsResponse, error)
-	getSandboxLogsFn         func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxLogsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxLogsResponse, error)
-	refreshSandboxFn         func(ctx context.Context, sandboxID apis.SandboxID, body apis.RefreshSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RefreshSandboxResponse, error)
-	listTemplatesFn          func(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error)
-	createTemplateV3Fn       func(ctx context.Context, body apis.CreateTemplateV3JSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateTemplateV3Response, error)
-	rebuildTemplateFn        func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error)
-	getTemplateFn            func(ctx context.Context, templateID apis.TemplateID, params *apis.GetTemplateParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateResponse, error)
-	deleteTemplateFn         func(ctx context.Context, templateID apis.TemplateID, editors ...apis.RequestEditorFn) (*apis.DeleteTemplateResponse, error)
-	getTemplateBuildStatusFn func(ctx context.Context, templateID apis.TemplateID, buildID apis.BuildID, params *apis.GetTemplateBuildStatusParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateBuildStatusResponse, error)
-	getTemplateByAliasFn     func(ctx context.Context, alias string, editors ...apis.RequestEditorFn) (*apis.GetTemplateByAliasResponse, error)
+	createSandboxFn            func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error)
+	getSandboxFn               func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxResponse, error)
+	deleteSandboxFn            func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.DeleteSandboxResponse, error)
+	listSandboxesFn            func(ctx context.Context, params *apis.ListSandboxesParams, editors ...apis.RequestEditorFn) (*apis.ListSandboxesResponse, error)
+	listSandboxesV2Fn          func(ctx context.Context, params *apis.ListSandboxesV2Params, editors ...apis.RequestEditorFn) (*apis.ListSandboxesV2Response, error)
+	connectSandboxFn           func(ctx context.Context, sandboxID apis.SandboxID, body apis.ConnectSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.ConnectSandboxResponse, error)
+	getSandboxInjectionsFn     func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxInjectionsResponse, error)
+	updateSandboxInjectionsFn  func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error)
+	updateSandboxGithubTokenFn func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxGithubTokenJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error)
+	updateSandboxTimeoutFn     func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxTimeoutJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxTimeoutResponse, error)
+	pauseSandboxFn             func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.PauseSandboxResponse, error)
+	getSandboxMetricsFn        func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxMetricsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxMetricsResponse, error)
+	getSandboxLogsFn           func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxLogsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxLogsResponse, error)
+	refreshSandboxFn           func(ctx context.Context, sandboxID apis.SandboxID, body apis.RefreshSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RefreshSandboxResponse, error)
+	listTemplatesFn            func(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error)
+	createTemplateV3Fn         func(ctx context.Context, body apis.CreateTemplateV3JSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateTemplateV3Response, error)
+	rebuildTemplateFn          func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error)
+	getTemplateFn              func(ctx context.Context, templateID apis.TemplateID, params *apis.GetTemplateParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateResponse, error)
+	deleteTemplateFn           func(ctx context.Context, templateID apis.TemplateID, editors ...apis.RequestEditorFn) (*apis.DeleteTemplateResponse, error)
+	getTemplateBuildStatusFn   func(ctx context.Context, templateID apis.TemplateID, buildID apis.BuildID, params *apis.GetTemplateBuildStatusParams, editors ...apis.RequestEditorFn) (*apis.GetTemplateBuildStatusResponse, error)
+	getTemplateByAliasFn       func(ctx context.Context, alias string, editors ...apis.RequestEditorFn) (*apis.GetTemplateByAliasResponse, error)
 }
 
 func httpResponse(statusCode int) *http.Response {
@@ -81,6 +86,26 @@ func (m *mockAPI) ConnectSandboxWithResponse(ctx context.Context, sandboxID apis
 }
 
 func (m *mockAPI) ConnectSandboxWithBodyWithResponse(ctx context.Context, sandboxID apis.SandboxID, contentType string, body io.Reader, editors ...apis.RequestEditorFn) (*apis.ConnectSandboxResponse, error) {
+	panic("not implemented")
+}
+
+func (m *mockAPI) GetSandboxInjectionsWithResponse(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxInjectionsResponse, error) {
+	return m.getSandboxInjectionsFn(ctx, sandboxID, editors...)
+}
+
+func (m *mockAPI) UpdateSandboxInjectionsWithResponse(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+	return m.updateSandboxInjectionsFn(ctx, sandboxID, body, editors...)
+}
+
+func (m *mockAPI) UpdateSandboxInjectionsWithBodyWithResponse(ctx context.Context, sandboxID apis.SandboxID, contentType string, body io.Reader, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+	panic("not implemented")
+}
+
+func (m *mockAPI) UpdateSandboxGithubTokenWithResponse(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxGithubTokenJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error) {
+	return m.updateSandboxGithubTokenFn(ctx, sandboxID, body, editors...)
+}
+
+func (m *mockAPI) UpdateSandboxGithubTokenWithBodyWithResponse(ctx context.Context, sandboxID apis.SandboxID, contentType string, body io.Reader, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error) {
 	panic("not implemented")
 }
 
@@ -697,6 +722,95 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestListFiltersByTemplates(t *testing.T) {
+	templates := []string{"tmpl-1", "qiniu/code-interpreter"}
+	mock := &mockAPI{
+		listSandboxesV2Fn: func(ctx context.Context, params *apis.ListSandboxesV2Params, editors ...apis.RequestEditorFn) (*apis.ListSandboxesV2Response, error) {
+			if params.Template == nil || !slices.Equal(*params.Template, templates) {
+				t.Fatalf("expected template filter %v, got %v", templates, params.Template)
+			}
+			list := []apis.ListedSandbox{}
+			return &apis.ListSandboxesV2Response{JSON200: &list, HTTPResponse: httpResponse(200)}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.List(context.Background(), &ListParams{Template: &templates})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetInjections(t *testing.T) {
+	var byID apis.SandboxInjection
+	if err := byID.FromInjectionByID(apis.InjectionByID{ID: "rule-1", Type: apis.ID}); err != nil {
+		t.Fatalf("create API injection: %v", err)
+	}
+	maskedHeader := map[string]string{"Authorization": "Bear****"}
+	var direct apis.SandboxInjection
+	if err := direct.FromHTTPInjection(apis.HTTPInjection{BaseURL: "api.example.com", Headers: &maskedHeader, Type: apis.HTTP}); err != nil {
+		t.Fatalf("create direct API injection: %v", err)
+	}
+	mock := &mockAPI{
+		getSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxInjectionsResponse, error) {
+			resp := &apis.GetSandboxInjectionsResponse{HTTPResponse: httpResponse(200)}
+			resp.JSON200 = &struct {
+				Injections []apis.SandboxInjection `json:"injections"`
+			}{Injections: []apis.SandboxInjection{byID, direct}}
+			return resp, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb := newTestSandbox(c, "sb-123")
+	injections, err := sb.GetInjections(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var _ []MaskedSandboxInjection = injections
+	if len(injections) != 2 || injections[0].ByID == nil || *injections[0].ByID != "rule-1" {
+		t.Fatalf("unexpected injections: %+v", injections)
+	}
+	if injections[1].HTTP == nil || injections[1].HTTP.BaseURL != "api.example.com" || !maps.Equal(*injections[1].HTTP.Headers, maskedHeader) {
+		t.Fatalf("unexpected direct injection: %+v", injections[1])
+	}
+}
+
+func TestUpdateInjections(t *testing.T) {
+	ruleID := "rule-1"
+	mock := &mockAPI{
+		updateSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+			if len(body.Injections) != 1 {
+				t.Fatalf("expected 1 injection, got %d", len(body.Injections))
+			}
+			byID, err := body.Injections[0].AsInjectionByID()
+			if err != nil || byID.ID != ruleID {
+				t.Fatalf("unexpected injection: %+v, err: %v", byID, err)
+			}
+			return &apis.UpdateSandboxInjectionsResponse{HTTPResponse: httpResponse(204)}, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb := newTestSandbox(c, "sb-123")
+	if err := sb.UpdateInjections(context.Background(), []SandboxInjectionSpec{{ByID: &ruleID}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateGitHubToken(t *testing.T) {
+	mock := &mockAPI{
+		updateSandboxGithubTokenFn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxGithubTokenJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error) {
+			if body.AuthorizationToken != "github-token" {
+				t.Fatalf("unexpected token: %q", body.AuthorizationToken)
+			}
+			return &apis.UpdateSandboxGithubTokenResponse{HTTPResponse: httpResponse(204)}, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb := newTestSandbox(c, "sb-123")
+	if err := sb.UpdateGitHubToken(context.Background(), "github-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- Sandbox.Kill ---
 
 func TestKill(t *testing.T) {
@@ -892,7 +1006,7 @@ func TestListTemplates(t *testing.T) {
 	mock := &mockAPI{
 		listTemplatesFn: func(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error) {
 			list := []apis.Template{
-				{TemplateID: "tmpl-1"},
+				{TemplateID: "tmpl-1", Names: []string{"qiniu/code-interpreter"}},
 				{TemplateID: "tmpl-2"},
 			}
 			return &apis.ListTemplatesResponse{
@@ -908,6 +1022,9 @@ func TestListTemplates(t *testing.T) {
 	}
 	if len(templates) != 2 {
 		t.Errorf("expected 2 templates, got %d", len(templates))
+	}
+	if !slices.Equal(templates[0].Names, []string{"qiniu/code-interpreter"}) {
+		t.Errorf("unexpected names: %v", templates[0].Names)
 	}
 }
 
@@ -1447,6 +1564,8 @@ func TestGetTemplate(t *testing.T) {
 			return &apis.GetTemplateResponse{
 				JSON200: &apis.TemplateWithBuilds{
 					TemplateID: templateID,
+					Names:      []string{"qiniu/code-interpreter"},
+					IsOwner:    true,
 					Builds:     []apis.TemplateBuild{{}},
 				},
 				HTTPResponse: httpResponse(200),
@@ -1463,6 +1582,12 @@ func TestGetTemplate(t *testing.T) {
 	}
 	if len(tmpl.Builds) != 1 {
 		t.Errorf("expected 1 build, got %d", len(tmpl.Builds))
+	}
+	if !slices.Equal(tmpl.Names, []string{"qiniu/code-interpreter"}) {
+		t.Errorf("unexpected names: %v", tmpl.Names)
+	}
+	if !tmpl.IsOwner {
+		t.Error("expected template to be owned by caller")
 	}
 }
 

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -769,7 +769,7 @@ func TestGetInjections(t *testing.T) {
 	if len(injections) != 2 || injections[0].ByID == nil || *injections[0].ByID != "rule-1" {
 		t.Fatalf("unexpected injections: %+v", injections)
 	}
-	if injections[1].HTTP == nil || injections[1].HTTP.BaseURL != "api.example.com" || !maps.Equal(*injections[1].HTTP.Headers, maskedHeader) {
+	if injections[1].HTTP == nil || injections[1].HTTP.BaseURL != "api.example.com" || injections[1].HTTP.Headers == nil || !maps.Equal(*injections[1].HTTP.Headers, maskedHeader) {
 		t.Fatalf("unexpected direct injection: %+v", injections[1])
 	}
 }

--- a/sandbox/doc.go
+++ b/sandbox/doc.go
@@ -48,6 +48,8 @@
 //   - [Sandbox.GetMetrics]: 获取 CPU、内存、磁盘等资源指标
 //   - [Sandbox.GetLogs]: 获取沙箱日志
 //   - [Sandbox.WaitForReady]: 轮询等待沙箱进入 running 状态
+//   - [Sandbox.GetInjections] / [Sandbox.UpdateInjections]: 查询和替换运行时请求注入规则
+//   - [Sandbox.UpdateGitHubToken]: 更新运行中沙箱的 GitHub 授权令牌
 //
 // # 命令执行
 //

--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -394,7 +394,7 @@ type InjectionRule struct {
 // KodoResource Kodo bucket resource mounted into the sandbox via NFS.
 // The platform creates an NFS-backed proxy that maps the Kodo bucket to a local path inside the sandbox.
 // Credentials (access_key/secret_key) are never exposed inside the sandbox.
-// Note: Kodo resource is only supported when creating a sandbox with Qiniu AKSK authentication. API key authentication is not supported.
+// Note: Kodo resources require access key authentication. API key authentication is not supported.
 type KodoResource struct {
 	// Bucket Kodo bucket name
 	Bucket string `json:"bucket"`
@@ -749,7 +749,8 @@ type TeamUser struct {
 
 // Template defines model for Template.
 type Template struct {
-	// Aliases Aliases of the template
+	// Aliases Aliases of the template (deprecated)
+	// Deprecated:
 	Aliases []string `json:"aliases"`
 
 	// BuildCount Number of times the template was built
@@ -779,6 +780,9 @@ type Template struct {
 
 	// MemoryMB Memory for the sandbox in MiB
 	MemoryMB MemoryMB `json:"memoryMB"`
+
+	// Names Names of the template (namespace/alias format when namespaced)
+	Names []string `json:"names"`
 
 	// Public Whether the template is public or only accessible by the team
 	Public bool `json:"public"`
@@ -1045,17 +1049,24 @@ type TemplateUpdateRequest struct {
 
 // TemplateWithBuilds defines model for TemplateWithBuilds.
 type TemplateWithBuilds struct {
-	// Aliases Aliases of the template
+	// Aliases Aliases of the template (deprecated)
+	// Deprecated:
 	Aliases []string `json:"aliases"`
 
-	// Builds List of builds for the template
+	// Builds List of builds for the template (empty for non-owning teams)
 	Builds []TemplateBuild `json:"builds"`
 
 	// CreatedAt Time when the template was created
 	CreatedAt time.Time `json:"createdAt"`
 
+	// IsOwner Whether the template is owned by the requesting team
+	IsOwner bool `json:"isOwner"`
+
 	// LastSpawnedAt Time when the template was last used
 	LastSpawnedAt *time.Time `json:"lastSpawnedAt"`
+
+	// Names Names of the template (namespace/alias format when namespaced)
+	Names []string `json:"names"`
 
 	// Public Whether the template is public or only accessible by the team
 	Public bool `json:"public"`
@@ -1124,6 +1135,18 @@ type ListSandboxesParams struct {
 type GetSandboxesMetricsParams struct {
 	// SandboxIds Comma-separated list of sandbox IDs to get metrics for
 	SandboxIds []string `form:"sandbox_ids" json:"sandbox_ids"`
+}
+
+// UpdateSandboxGithubTokenJSONBody defines parameters for UpdateSandboxGithubToken.
+type UpdateSandboxGithubTokenJSONBody struct {
+	// AuthorizationToken New GitHub authorization token
+	AuthorizationToken string `json:"authorization_token"`
+}
+
+// UpdateSandboxInjectionsJSONBody defines parameters for UpdateSandboxInjections.
+type UpdateSandboxInjectionsJSONBody struct {
+	// Injections New injection rules. Fully replaces the existing configuration.
+	Injections []SandboxInjection `json:"injections"`
 }
 
 // GetSandboxLogsParams defines parameters for GetSandboxLogs.
@@ -1197,6 +1220,9 @@ type ListSandboxesV2Params struct {
 	// Metadata Metadata query used to filter the sandboxes (e.g. "user=abc&app=prod"). Each key and values must be URL encoded.
 	Metadata *string `form:"metadata,omitempty" json:"metadata,omitempty"`
 
+	// Template Filter sandboxes by one or more template IDs or aliases. Maximum 20 values.
+	Template *[]string `form:"template,omitempty" json:"template,omitempty"`
+
 	// State Filter sandboxes by one or more states
 	State *[]SandboxState `form:"state,omitempty" json:"state,omitempty"`
 
@@ -1218,6 +1244,12 @@ type CreateSandboxJSONRequestBody = NewSandbox
 
 // ConnectSandboxJSONRequestBody defines body for ConnectSandbox for application/json ContentType.
 type ConnectSandboxJSONRequestBody = ConnectSandbox
+
+// UpdateSandboxGithubTokenJSONRequestBody defines body for UpdateSandboxGithubToken for application/json ContentType.
+type UpdateSandboxGithubTokenJSONRequestBody UpdateSandboxGithubTokenJSONBody
+
+// UpdateSandboxInjectionsJSONRequestBody defines body for UpdateSandboxInjections for application/json ContentType.
+type UpdateSandboxInjectionsJSONRequestBody UpdateSandboxInjectionsJSONBody
 
 // RefreshSandboxJSONRequestBody defines body for RefreshSandbox for application/json ContentType.
 type RefreshSandboxJSONRequestBody RefreshSandboxJSONBody
@@ -2025,6 +2057,19 @@ type ClientInterface interface {
 
 	ConnectSandbox(ctx context.Context, sandboxID SandboxID, body ConnectSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UpdateSandboxGithubTokenWithBody request with any body
+	UpdateSandboxGithubTokenWithBody(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateSandboxGithubToken(ctx context.Context, sandboxID SandboxID, body UpdateSandboxGithubTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSandboxInjections request
+	GetSandboxInjections(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateSandboxInjectionsWithBody request with any body
+	UpdateSandboxInjectionsWithBody(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateSandboxInjections(ctx context.Context, sandboxID SandboxID, body UpdateSandboxInjectionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetSandboxLogs request
 	GetSandboxLogs(ctx context.Context, sandboxID SandboxID, params *GetSandboxLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2299,6 +2344,66 @@ func (c *Client) ConnectSandboxWithBody(ctx context.Context, sandboxID SandboxID
 
 func (c *Client) ConnectSandbox(ctx context.Context, sandboxID SandboxID, body ConnectSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewConnectSandboxRequest(c.Server, sandboxID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSandboxGithubTokenWithBody(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSandboxGithubTokenRequestWithBody(c.Server, sandboxID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSandboxGithubToken(ctx context.Context, sandboxID SandboxID, body UpdateSandboxGithubTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSandboxGithubTokenRequest(c.Server, sandboxID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSandboxInjections(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSandboxInjectionsRequest(c.Server, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSandboxInjectionsWithBody(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSandboxInjectionsRequestWithBody(c.Server, sandboxID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSandboxInjections(ctx context.Context, sandboxID SandboxID, body UpdateSandboxInjectionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSandboxInjectionsRequest(c.Server, sandboxID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3166,6 +3271,134 @@ func NewConnectSandboxRequestWithBody(server string, sandboxID SandboxID, conten
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUpdateSandboxGithubTokenRequest calls the generic UpdateSandboxGithubToken builder with application/json body
+func NewUpdateSandboxGithubTokenRequest(server string, sandboxID SandboxID, body UpdateSandboxGithubTokenJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateSandboxGithubTokenRequestWithBody(server, sandboxID, "application/json", bodyReader)
+}
+
+// NewUpdateSandboxGithubTokenRequestWithBody generates requests for UpdateSandboxGithubToken with any type of body
+func NewUpdateSandboxGithubTokenRequestWithBody(server string, sandboxID SandboxID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "sandboxID", runtime.ParamLocationPath, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sandboxes/%s/github-token", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetSandboxInjectionsRequest generates requests for GetSandboxInjections
+func NewGetSandboxInjectionsRequest(server string, sandboxID SandboxID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "sandboxID", runtime.ParamLocationPath, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sandboxes/%s/injections", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateSandboxInjectionsRequest calls the generic UpdateSandboxInjections builder with application/json body
+func NewUpdateSandboxInjectionsRequest(server string, sandboxID SandboxID, body UpdateSandboxInjectionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateSandboxInjectionsRequestWithBody(server, sandboxID, "application/json", bodyReader)
+}
+
+// NewUpdateSandboxInjectionsRequestWithBody generates requests for UpdateSandboxInjections with any type of body
+func NewUpdateSandboxInjectionsRequestWithBody(server string, sandboxID SandboxID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "sandboxID", runtime.ParamLocationPath, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sandboxes/%s/injections", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -4239,6 +4472,22 @@ func NewListSandboxesV2Request(server string, params *ListSandboxesV2Params) (*h
 
 		}
 
+		if params.Template != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "template", runtime.ParamLocationQuery, *params.Template); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.State != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "state", runtime.ParamLocationQuery, *params.State); err != nil {
@@ -4518,6 +4767,19 @@ type ClientWithResponsesInterface interface {
 	ConnectSandboxWithBodyWithResponse(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ConnectSandboxResponse, error)
 
 	ConnectSandboxWithResponse(ctx context.Context, sandboxID SandboxID, body ConnectSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*ConnectSandboxResponse, error)
+
+	// UpdateSandboxGithubTokenWithBodyWithResponse request with any body
+	UpdateSandboxGithubTokenWithBodyWithResponse(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSandboxGithubTokenResponse, error)
+
+	UpdateSandboxGithubTokenWithResponse(ctx context.Context, sandboxID SandboxID, body UpdateSandboxGithubTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSandboxGithubTokenResponse, error)
+
+	// GetSandboxInjectionsWithResponse request
+	GetSandboxInjectionsWithResponse(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*GetSandboxInjectionsResponse, error)
+
+	// UpdateSandboxInjectionsWithBodyWithResponse request with any body
+	UpdateSandboxInjectionsWithBodyWithResponse(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSandboxInjectionsResponse, error)
+
+	UpdateSandboxInjectionsWithResponse(ctx context.Context, sandboxID SandboxID, body UpdateSandboxInjectionsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSandboxInjectionsResponse, error)
 
 	// GetSandboxLogsWithResponse request
 	GetSandboxLogsWithResponse(ctx context.Context, sandboxID SandboxID, params *GetSandboxLogsParams, reqEditors ...RequestEditorFn) (*GetSandboxLogsResponse, error)
@@ -4906,6 +5168,83 @@ func (r ConnectSandboxResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ConnectSandboxResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateSandboxGithubTokenResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *N400
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateSandboxGithubTokenResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateSandboxGithubTokenResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetSandboxInjectionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Injections []SandboxInjection `json:"injections"`
+	}
+	JSON401 *N401
+	JSON404 *N404
+	JSON500 *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSandboxInjectionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSandboxInjectionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateSandboxInjectionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *N400
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateSandboxInjectionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateSandboxInjectionsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5617,6 +5956,49 @@ func (c *ClientWithResponses) ConnectSandboxWithResponse(ctx context.Context, sa
 		return nil, err
 	}
 	return ParseConnectSandboxResponse(rsp)
+}
+
+// UpdateSandboxGithubTokenWithBodyWithResponse request with arbitrary body returning *UpdateSandboxGithubTokenResponse
+func (c *ClientWithResponses) UpdateSandboxGithubTokenWithBodyWithResponse(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSandboxGithubTokenResponse, error) {
+	rsp, err := c.UpdateSandboxGithubTokenWithBody(ctx, sandboxID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSandboxGithubTokenResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateSandboxGithubTokenWithResponse(ctx context.Context, sandboxID SandboxID, body UpdateSandboxGithubTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSandboxGithubTokenResponse, error) {
+	rsp, err := c.UpdateSandboxGithubToken(ctx, sandboxID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSandboxGithubTokenResponse(rsp)
+}
+
+// GetSandboxInjectionsWithResponse request returning *GetSandboxInjectionsResponse
+func (c *ClientWithResponses) GetSandboxInjectionsWithResponse(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*GetSandboxInjectionsResponse, error) {
+	rsp, err := c.GetSandboxInjections(ctx, sandboxID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSandboxInjectionsResponse(rsp)
+}
+
+// UpdateSandboxInjectionsWithBodyWithResponse request with arbitrary body returning *UpdateSandboxInjectionsResponse
+func (c *ClientWithResponses) UpdateSandboxInjectionsWithBodyWithResponse(ctx context.Context, sandboxID SandboxID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSandboxInjectionsResponse, error) {
+	rsp, err := c.UpdateSandboxInjectionsWithBody(ctx, sandboxID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSandboxInjectionsResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateSandboxInjectionsWithResponse(ctx context.Context, sandboxID SandboxID, body UpdateSandboxInjectionsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSandboxInjectionsResponse, error) {
+	rsp, err := c.UpdateSandboxInjections(ctx, sandboxID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSandboxInjectionsResponse(rsp)
 }
 
 // GetSandboxLogsWithResponse request returning *GetSandboxLogsResponse
@@ -6452,6 +6834,149 @@ func ParseConnectSandboxResponse(rsp *http.Response) (*ConnectSandboxResponse, e
 		}
 		response.JSON201 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateSandboxGithubTokenResponse parses an HTTP response from a UpdateSandboxGithubTokenWithResponse call
+func ParseUpdateSandboxGithubTokenResponse(rsp *http.Response) (*UpdateSandboxGithubTokenResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateSandboxGithubTokenResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSandboxInjectionsResponse parses an HTTP response from a GetSandboxInjectionsWithResponse call
+func ParseGetSandboxInjectionsResponse(rsp *http.Response) (*GetSandboxInjectionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSandboxInjectionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Injections []SandboxInjection `json:"injections"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateSandboxInjectionsResponse parses an HTTP response from a UpdateSandboxInjectionsWithResponse call
+func ParseUpdateSandboxInjectionsResponse(rsp *http.Response) (*UpdateSandboxInjectionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateSandboxInjectionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -172,6 +172,57 @@ func (c *Client) List(ctx context.Context, params *ListParams) ([]ListedSandbox,
 	return listedSandboxesFromAPI(*resp.JSON200), nil
 }
 
+// GetInjections 返回沙箱当前的运行时请求注入规则。
+// 响应中的密钥、令牌和 Header 等敏感字段由服务端脱敏。
+// 返回值不能直接用于 UpdateInjections；更新时必须提供包含真实敏感值的新配置。
+func (s *Sandbox) GetInjections(ctx context.Context) ([]MaskedSandboxInjection, error) {
+	resp, err := s.client.api.GetSandboxInjectionsWithResponse(ctx, s.sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, newAPIError(resp.HTTPResponse, resp.Body)
+	}
+	return maskedSandboxInjectionsFromAPI(resp.JSON200.Injections)
+}
+
+// UpdateInjections 替换沙箱的全部运行时请求注入规则。
+// 变更会立即应用于新的出站 HTTPS 连接。
+func (s *Sandbox) UpdateInjections(ctx context.Context, injections []SandboxInjectionSpec) error {
+	apiInjections := make([]apis.SandboxInjection, len(injections))
+	for i, injection := range injections {
+		apiInjection, err := sandboxInjectionSpecToAPI(injection)
+		if err != nil {
+			return err
+		}
+		apiInjections[i] = apiInjection
+	}
+	resp, err := s.client.api.UpdateSandboxInjectionsWithResponse(ctx, s.sandboxID, apis.UpdateSandboxInjectionsJSONRequestBody{
+		Injections: apiInjections,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.HTTPResponse.StatusCode != http.StatusNoContent {
+		return newAPIError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+// UpdateGitHubToken 更新沙箱使用的 GitHub 授权令牌。
+func (s *Sandbox) UpdateGitHubToken(ctx context.Context, authorizationToken string) error {
+	resp, err := s.client.api.UpdateSandboxGithubTokenWithResponse(ctx, s.sandboxID, apis.UpdateSandboxGithubTokenJSONRequestBody{
+		AuthorizationToken: authorizationToken,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.HTTPResponse.StatusCode != http.StatusNoContent {
+		return newAPIError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
 // Kill 终止沙箱。
 func (s *Sandbox) Kill(ctx context.Context) error {
 	resp, err := s.client.api.DeleteSandboxWithResponse(ctx, s.sandboxID)

--- a/sandbox/types.go
+++ b/sandbox/types.go
@@ -101,6 +101,9 @@ type ListParams struct {
 	// Metadata 用于过滤沙箱的元数据查询（如 "user=abc&app=prod"）。
 	Metadata *string
 
+	// Template 按一个或多个模板 ID 或名称过滤沙箱，最多 20 个值。
+	Template *[]string
+
 	// State 按一个或多个状态过滤沙箱。
 	State *[]SandboxState
 
@@ -425,6 +428,7 @@ func (p *ListParams) toAPI() *apis.ListSandboxesV2Params {
 		Metadata:  p.Metadata,
 		NextToken: p.NextToken,
 		Limit:     p.Limit,
+		Template:  p.Template,
 	}
 	if p.State != nil {
 		states := make([]apis.SandboxState, len(*p.State))

--- a/sandbox/types_injection_rule.go
+++ b/sandbox/types_injection_rule.go
@@ -160,6 +160,32 @@ type SandboxInjectionSpec struct {
 	HTTP *HTTPInjection
 }
 
+// MaskedSandboxInjection 沙箱当前的请求注入配置查询结果。
+// APIKey、Token 和 Headers 等敏感字段仅包含服务端返回的脱敏值。
+// 该类型与可写的 SandboxInjectionSpec 保持分离，不能直接用于更新配置。
+type MaskedSandboxInjection struct {
+	// ByID 引用的已保存注入规则 ID。
+	ByID *string
+
+	// OpenAI 已脱敏的 OpenAI 兼容 API 注入配置。
+	OpenAI *OpenAIInjection
+
+	// Anthropic 已脱敏的 Anthropic API 注入配置。
+	Anthropic *AnthropicInjection
+
+	// Gemini 已脱敏的 Google Gemini API 注入配置。
+	Gemini *GeminiInjection
+
+	// Qiniu 已脱敏的七牛 AI API 注入配置。
+	Qiniu *QiniuInjection
+
+	// Github 已脱敏的 GitHub 凭证注入配置。
+	Github *GithubInjection
+
+	// HTTP 已脱敏的自定义 HTTP 注入配置。
+	HTTP *HTTPInjection
+}
+
 // InjectionRule 预定义的请求注入规则。
 type InjectionRule struct {
 	// RuleID 规则唯一标识。
@@ -446,6 +472,74 @@ func injectionSpecFromAPI(inj apis.Injection) (InjectionSpec, error) {
 	default:
 		return InjectionSpec{}, fmt.Errorf("unknown injection type: %s", disc)
 	}
+}
+
+func maskedSandboxInjectionFromAPI(inj apis.SandboxInjection) (MaskedSandboxInjection, error) {
+	disc, err := inj.Discriminator()
+	if err != nil {
+		return MaskedSandboxInjection{}, err
+	}
+	switch disc {
+	case string(apis.ID):
+		v, err := inj.AsInjectionByID()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{ByID: &v.ID}, nil
+	case string(apis.Openai):
+		v, err := inj.AsOpenaiInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{OpenAI: &OpenAIInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
+	case string(apis.Anthropic):
+		v, err := inj.AsAnthropicInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{Anthropic: &AnthropicInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
+	case string(apis.Gemini):
+		v, err := inj.AsGeminiInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{Gemini: &GeminiInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
+	case string(apis.Qiniu):
+		v, err := inj.AsQiniuInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{Qiniu: &QiniuInjection{APIKey: v.APIKey, BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
+	case string(apis.Github):
+		v, err := inj.AsGithubInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{Github: &GithubInjection{BaseURL: v.BaseURL, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries, Token: v.Token}}, nil
+	case string(apis.HTTP):
+		v, err := inj.AsHTTPInjection()
+		if err != nil {
+			return MaskedSandboxInjection{}, err
+		}
+		return MaskedSandboxInjection{HTTP: &HTTPInjection{BaseURL: v.BaseURL, Headers: v.Headers, IfHeaders: v.IfHeaders, IfQueries: v.IfQueries}}, nil
+	default:
+		return MaskedSandboxInjection{}, fmt.Errorf("unknown sandbox injection type: %s", disc)
+	}
+}
+
+func maskedSandboxInjectionsFromAPI(injections []apis.SandboxInjection) ([]MaskedSandboxInjection, error) {
+	if injections == nil {
+		return nil, nil
+	}
+	result := make([]MaskedSandboxInjection, len(injections))
+	for i, injection := range injections {
+		spec, err := maskedSandboxInjectionFromAPI(injection)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = spec
+	}
+	return result, nil
 }
 
 func injectionRuleFromAPI(a apis.InjectionRule) (InjectionRule, error) {

--- a/sandbox/types_template.go
+++ b/sandbox/types_template.go
@@ -349,8 +349,12 @@ func (p *DeleteTagsParams) toAPI() apis.DeleteTemplateTagsJSONRequestBody {
 
 // Template 模板信息。
 type Template struct {
-	TemplateID    string
-	Aliases       []string
+	TemplateID string
+	// Aliases 模板别名（已弃用，请使用 Names）。
+	// Deprecated: 使用 Names。
+	Aliases []string
+	// Names 模板名称，使用命名空间/别名格式。
+	Names         []string
 	BuildID       string
 	BuildStatus   TemplateBuildStatus
 	BuildCount    int32
@@ -380,8 +384,14 @@ type TemplateBuild struct {
 
 // TemplateWithBuilds 模板及其构建记录。
 type TemplateWithBuilds struct {
-	TemplateID    string
-	Aliases       []string
+	TemplateID string
+	// Aliases 模板别名（已弃用，请使用 Names）。
+	// Deprecated: 使用 Names。
+	Aliases []string
+	// Names 模板名称，使用命名空间/别名格式。
+	Names []string
+	// IsOwner 表示模板是否归当前请求团队所有。
+	IsOwner       bool
 	Public        bool
 	SpawnCount    int64
 	CreatedAt     time.Time
@@ -449,6 +459,7 @@ func templateFromAPI(a apis.Template) Template {
 	return Template{
 		TemplateID:    a.TemplateID,
 		Aliases:       a.Aliases,
+		Names:         a.Names,
 		BuildID:       a.BuildID,
 		BuildStatus:   TemplateBuildStatus(a.BuildStatus),
 		BuildCount:    a.BuildCount,
@@ -496,6 +507,8 @@ func templateWithBuildsFromAPI(a *apis.TemplateWithBuilds) *TemplateWithBuilds {
 	result := &TemplateWithBuilds{
 		TemplateID:    a.TemplateID,
 		Aliases:       a.Aliases,
+		Names:         a.Names,
+		IsOwner:       a.IsOwner,
 		Public:        a.Public,
 		SpawnCount:    a.SpawnCount,
 		CreatedAt:     a.CreatedAt,


### PR DESCRIPTION
## Summary

- update the `api-specs` submodule to include qiniu/api-specs#21 and qiniu/api-specs#22, then regenerate the Sandbox control-plane client
- expose template filtering, template names, and template ownership through the public Sandbox SDK
- add runtime injection retrieval/replacement and GitHub token update APIs
- keep masked injection query results separate from writable injection specs to prevent accidental credential replacement

## Motivation

The Sandbox public OpenAPI contract added new template metadata, list filters, and runtime configuration endpoints. The Go SDK needs matching generated bindings and public wrappers so callers can use these capabilities without reaching into generated internal APIs.

## Validation

- `gofmt -s -l .`
- `make staticcheck`
- `make unittest`
- `go build ./...`
- `git diff --check`
