### PR TITLE
test(sandbox): complete tests and examples for new APIs

### DIFF
--- a/examples/sandbox_list/main.go
+++ b/examples/sandbox_list/main.go
@@ -51,6 +51,17 @@ func main() {
 	}
 	fmt.Printf("共 %d 个 running 状态的沙箱\n", len(filtered))
 
+	// 按一个或多个模板 ID / 名称过滤，最多可传 20 个值。
+	fmt.Println("\n=== 按模板过滤 ===")
+	templates := []string{"base"}
+	filteredByTemplate, err := c.List(ctx, &sandbox.ListParams{
+		Template: &templates,
+	})
+	if err != nil {
+		log.Fatalf("按模板列出沙箱失败: %v", err)
+	}
+	fmt.Printf("模板 %v 下共有 %d 个沙箱\n", templates, len(filteredByTemplate))
+
 	// 批量获取沙箱指标
 	if len(sandboxes) > 0 {
 		fmt.Println("\n=== 批量获取沙箱指标 ===")

--- a/examples/sandbox_request_injections/main.go
+++ b/examples/sandbox_request_injections/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/qiniu/go-sdk/v7/sandbox"
 )
@@ -32,7 +33,7 @@ func main() {
 	log.Println("Creating sandbox with request injections...")
 
 	// 设置针对特定域名的请求注入规则
-	// 这个规则告诉底层网络架构，当请求向 "httpbin.org" 发起时，
+	// 这个规则告诉底层网络架构，当请求向 "httpbingo.org" 发起时，
 	// 如果它是 HTTPS，拦截掉该请求并将 header 中的 "Authorization"
 	// 重写为 "Bearer real_xxx"
 	headers := map[string]string{
@@ -45,19 +46,28 @@ func main() {
 		"inject": "true",
 	}
 
-	// 准备创建参数（HTTP 自定义注入）
-	params := sandbox.CreateParams{
-		TemplateID: "base",
-		Injections: &[]sandbox.SandboxInjectionSpec{
-			{
-				HTTP: &sandbox.HTTPInjection{
-					BaseURL:   "https://httpbin.org",
-					Headers:   &headers,
-					IfHeaders: &ifHeaders,
-					IfQueries: &ifQueries,
-				},
+	// 准备创建参数（HTTP 自定义注入）。如果设置了 QINIU_GITHUB_TOKEN，
+	// 同时演示 GitHub 凭证注入和运行时 token 更新。
+	injections := []sandbox.SandboxInjectionSpec{
+		{
+			HTTP: &sandbox.HTTPInjection{
+				BaseURL:   "https://httpbingo.org",
+				Headers:   &headers,
+				IfHeaders: &ifHeaders,
+				IfQueries: &ifQueries,
 			},
 		},
+	}
+	githubToken := os.Getenv("QINIU_GITHUB_TOKEN")
+	if githubToken != "" {
+		injections = append(injections, sandbox.SandboxInjectionSpec{
+			Github: &sandbox.GithubInjection{Token: &githubToken},
+		})
+	}
+
+	params := sandbox.CreateParams{
+		TemplateID: "base",
+		Injections: &injections,
 	}
 
 	// 也可以使用已知 API 协议的快捷注入（OpenAI、Anthropic、Gemini）
@@ -95,24 +105,95 @@ func main() {
 
 	log.Printf("Sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
 
+	// 查询当前运行时注入。敏感字段由服务端脱敏，返回值不能直接用于更新。
+	current, err := sb.GetInjections(ctx)
+	if err != nil {
+		log.Fatalf("Failed to get runtime injections: %v", err)
+	}
+	logMaskedInjections("Current runtime injections", current)
+
 	// 在沙箱内执行使用假 APIKEY 的请求
 	// 沙箱内的程序完全感觉不到外部注入；只有请求同时满足 IfHeaders / IfQueries
 	// 匹配条件时，外层才会拦截并替换为真实的 Key。
-	fakeTokenCmd := `curl -sSL -X GET "https://httpbin.org/bearer?inject=true" -H "accept: application/json" -H "Authorization: Bearer fake_xxx" -H "X-Injection-Scope: demo"`
-	log.Printf("Executing command in sandbox:\n$ %s\n", fakeTokenCmd)
+	fakeTokenCmd := `curl -sSL -X GET "https://httpbingo.org/bearer?inject=true" -H "accept: application/json" -H "Authorization: Bearer fake_xxx" -H "X-Injection-Scope: demo"`
+	runBearerCheck(ctx, sb, fakeTokenCmd, "real_xxx")
 
-	result, err := sb.Commands().Run(ctx, fakeTokenCmd)
+	// 替换运行中沙箱的全部注入规则。更新接口需要重新提供真实敏感值。
+	updatedHeaders := map[string]string{
+		"Authorization": "Bearer updated_xxx",
+	}
+	updatedInjections := []sandbox.SandboxInjectionSpec{
+		{
+			HTTP: &sandbox.HTTPInjection{
+				BaseURL:   "https://httpbingo.org",
+				Headers:   &updatedHeaders,
+				IfHeaders: &ifHeaders,
+				IfQueries: &ifQueries,
+			},
+		},
+	}
+	if githubToken != "" {
+		updatedInjections = append(updatedInjections, sandbox.SandboxInjectionSpec{
+			Github: &sandbox.GithubInjection{Token: &githubToken},
+		})
+	}
+	if err := sb.UpdateInjections(ctx, updatedInjections); err != nil {
+		log.Fatalf("Failed to update runtime injections: %v", err)
+	}
+	current, err = sb.GetInjections(ctx)
+	if err != nil {
+		log.Fatalf("Failed to get updated runtime injections: %v", err)
+	}
+	logMaskedInjections("Updated runtime injections", current)
+	runBearerCheck(ctx, sb, fakeTokenCmd, "updated_xxx")
+
+	// 已配置 GitHub 注入时，可独立轮换 GitHub token，无需替换其他注入规则。
+	if updatedGitHubToken := os.Getenv("QINIU_GITHUB_TOKEN_UPDATED"); updatedGitHubToken != "" {
+		if githubToken == "" {
+			log.Fatal("设置 QINIU_GITHUB_TOKEN_UPDATED 时也必须设置 QINIU_GITHUB_TOKEN")
+		}
+		if err := sb.UpdateGitHubToken(ctx, updatedGitHubToken); err != nil {
+			log.Fatalf("Failed to update GitHub token: %v", err)
+		}
+		log.Println("GitHub token updated successfully")
+	}
+}
+
+func runBearerCheck(ctx context.Context, sb *sandbox.Sandbox, command, expectedToken string) {
+	log.Printf("Executing command in sandbox:\n$ %s\n", command)
+	result, err := sb.Commands().Run(ctx, command)
 	if err != nil {
 		log.Fatalf("Failed to run command: %v", err)
 	}
-
-	// 打印输出，应当能看到 real_xxx 出现在 token 字段中
-	log.Println("Command Execution Result:", result.ExitCode)
-	if result.Error != "" {
-		log.Printf("Error: %s\n", result.Error)
+	if result.ExitCode != 0 {
+		log.Fatalf("Command failed with exit code %d: %s", result.ExitCode, result.Stderr)
 	}
-	log.Printf("Stdout: \n%s\n", result.Stdout)
-	if result.Stderr != "" {
-		log.Printf("Stderr: \n%s\n", result.Stderr)
+	if !strings.Contains(result.Stdout, `"token": "`+expectedToken+`"`) {
+		log.Fatalf("Request injection did not replace the bearer token, stdout: %s", result.Stdout)
+	}
+	log.Printf("Request injection verified with token %q", expectedToken)
+}
+
+func logMaskedInjections(label string, injections []sandbox.MaskedSandboxInjection) {
+	log.Printf("%s (%d):", label, len(injections))
+	for i, injection := range injections {
+		switch {
+		case injection.ByID != nil:
+			log.Printf("  %d. rule ID: %s", i+1, *injection.ByID)
+		case injection.OpenAI != nil:
+			log.Printf("  %d. OpenAI injection", i+1)
+		case injection.Anthropic != nil:
+			log.Printf("  %d. Anthropic injection", i+1)
+		case injection.Gemini != nil:
+			log.Printf("  %d. Gemini injection", i+1)
+		case injection.Qiniu != nil:
+			log.Printf("  %d. Qiniu injection", i+1)
+		case injection.Github != nil:
+			log.Printf("  %d. GitHub injection", i+1)
+		case injection.HTTP != nil:
+			log.Printf("  %d. HTTP injection for %s", i+1, injection.HTTP.BaseURL)
+		default:
+			log.Printf("  %d. unknown injection", i+1)
+		}
 	}
 }

--- a/examples/sandbox_request_injections/main.go
+++ b/examples/sandbox_request_injections/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -29,7 +30,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
+	if err := run(ctx, client); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func run(ctx context.Context, client *sandbox.Client) error {
 	log.Println("Creating sandbox with request injections...")
 
 	// 设置针对特定域名的请求注入规则
@@ -96,11 +102,13 @@ func main() {
 	// 创建并等待沙箱就绪
 	sb, info, err := client.CreateAndWait(ctx, params)
 	if err != nil {
-		log.Fatalf("Failed to create sandbox: %v", err)
+		return fmt.Errorf("failed to create sandbox: %w", err)
 	}
 	defer func() {
 		log.Println("Killing sandbox...")
-		_ = sb.Kill(ctx)
+		if err := sb.Kill(ctx); err != nil {
+			log.Printf("Failed to kill sandbox: %v", err)
+		}
 	}()
 
 	log.Printf("Sandbox created successfully! ID: %s, State: %s\n", sb.ID(), info.State)
@@ -108,7 +116,7 @@ func main() {
 	// 查询当前运行时注入。敏感字段由服务端脱敏，返回值不能直接用于更新。
 	current, err := sb.GetInjections(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get runtime injections: %v", err)
+		return fmt.Errorf("failed to get runtime injections: %w", err)
 	}
 	logMaskedInjections("Current runtime injections", current)
 
@@ -116,7 +124,9 @@ func main() {
 	// 沙箱内的程序完全感觉不到外部注入；只有请求同时满足 IfHeaders / IfQueries
 	// 匹配条件时，外层才会拦截并替换为真实的 Key。
 	fakeTokenCmd := `curl -sSL -X GET "https://httpbingo.org/bearer?inject=true" -H "accept: application/json" -H "Authorization: Bearer fake_xxx" -H "X-Injection-Scope: demo"`
-	runBearerCheck(ctx, sb, fakeTokenCmd, "real_xxx")
+	if err := runBearerCheck(ctx, sb, fakeTokenCmd, "real_xxx"); err != nil {
+		return err
+	}
 
 	// 替换运行中沙箱的全部注入规则。更新接口需要重新提供真实敏感值。
 	updatedHeaders := map[string]string{
@@ -138,40 +148,44 @@ func main() {
 		})
 	}
 	if err := sb.UpdateInjections(ctx, updatedInjections); err != nil {
-		log.Fatalf("Failed to update runtime injections: %v", err)
+		return fmt.Errorf("failed to update runtime injections: %w", err)
 	}
 	current, err = sb.GetInjections(ctx)
 	if err != nil {
-		log.Fatalf("Failed to get updated runtime injections: %v", err)
+		return fmt.Errorf("failed to get updated runtime injections: %w", err)
 	}
 	logMaskedInjections("Updated runtime injections", current)
-	runBearerCheck(ctx, sb, fakeTokenCmd, "updated_xxx")
+	if err := runBearerCheck(ctx, sb, fakeTokenCmd, "updated_xxx"); err != nil {
+		return err
+	}
 
 	// 已配置 GitHub 注入时，可独立轮换 GitHub token，无需替换其他注入规则。
 	if updatedGitHubToken := os.Getenv("QINIU_GITHUB_TOKEN_UPDATED"); updatedGitHubToken != "" {
 		if githubToken == "" {
-			log.Fatal("设置 QINIU_GITHUB_TOKEN_UPDATED 时也必须设置 QINIU_GITHUB_TOKEN")
+			return fmt.Errorf("设置 QINIU_GITHUB_TOKEN_UPDATED 时也必须设置 QINIU_GITHUB_TOKEN")
 		}
 		if err := sb.UpdateGitHubToken(ctx, updatedGitHubToken); err != nil {
-			log.Fatalf("Failed to update GitHub token: %v", err)
+			return fmt.Errorf("failed to update GitHub token: %w", err)
 		}
 		log.Println("GitHub token updated successfully")
 	}
+	return nil
 }
 
-func runBearerCheck(ctx context.Context, sb *sandbox.Sandbox, command, expectedToken string) {
+func runBearerCheck(ctx context.Context, sb *sandbox.Sandbox, command, expectedToken string) error {
 	log.Printf("Executing command in sandbox:\n$ %s\n", command)
 	result, err := sb.Commands().Run(ctx, command)
 	if err != nil {
-		log.Fatalf("Failed to run command: %v", err)
+		return fmt.Errorf("failed to run command: %w", err)
 	}
 	if result.ExitCode != 0 {
-		log.Fatalf("Command failed with exit code %d: %s", result.ExitCode, result.Stderr)
+		return fmt.Errorf("command failed with exit code %d: %s", result.ExitCode, result.Stderr)
 	}
 	if !strings.Contains(result.Stdout, `"token": "`+expectedToken+`"`) {
-		log.Fatalf("Request injection did not replace the bearer token, stdout: %s", result.Stdout)
+		return fmt.Errorf("request injection did not replace the bearer token, stdout: %s", result.Stdout)
 	}
 	log.Printf("Request injection verified with token %q", expectedToken)
+	return nil
 }
 
 func logMaskedInjections(label string, injections []sandbox.MaskedSandboxInjection) {

--- a/examples/sandbox_templates/main.go
+++ b/examples/sandbox_templates/main.go
@@ -37,12 +37,16 @@ func main() {
 	}
 	fmt.Printf("共 %d 个模板:\n", len(templates))
 	for _, tmpl := range templates {
+		names := "-"
+		if len(tmpl.Names) > 0 {
+			names = fmt.Sprintf("%v", tmpl.Names)
+		}
 		aliases := "-"
 		if len(tmpl.Aliases) > 0 {
 			aliases = fmt.Sprintf("%v", tmpl.Aliases)
 		}
 		fmt.Printf("  - %s\n", tmpl.TemplateID)
-		fmt.Printf("    别名: %s, 公开: %v\n", aliases, tmpl.Public)
+		fmt.Printf("    名称: %s, 旧别名: %s, 公开: %v\n", names, aliases, tmpl.Public)
 		fmt.Printf("    CPU: %d 核, 内存: %d MB, 磁盘: %d MB, envd: %s\n",
 			tmpl.CPUCount, tmpl.MemoryMB, tmpl.DiskSizeMB, tmpl.EnvdVersion)
 		fmt.Printf("    构建状态: %s, 构建次数: %d, 使用次数: %d\n",
@@ -58,7 +62,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("获取模板详情失败: %v", err)
 		}
-		fmt.Printf("模板: %s, 构建数: %d\n", detail.TemplateID, len(detail.Builds))
+		fmt.Printf("模板: %s, 名称: %v, 当前用户拥有: %v, 构建数: %d\n",
+			detail.TemplateID, detail.Names, detail.IsOwner, len(detail.Builds))
 		for i, build := range detail.Builds {
 			if i >= 3 {
 				fmt.Printf("  ... 省略 %d 条\n", len(detail.Builds)-3)
@@ -67,6 +72,13 @@ func main() {
 			fmt.Printf("  - %s (状态: %s, CPU: %d, 内存: %d MB)\n",
 				build.BuildID, build.Status, build.CPUCount, build.MemoryMB)
 		}
+	}
+
+	// 模板创建和构建会消耗云端资源，默认只运行上面的只读示例。
+	// 如需继续验证写操作，请显式设置 QINIU_SANDBOX_TEMPLATE_MUTATION_EXAMPLE=true。
+	if os.Getenv("QINIU_SANDBOX_TEMPLATE_MUTATION_EXAMPLE") != "true" {
+		fmt.Println("\n未启用模板写操作示例，跳过创建、构建和删除流程")
+		return
 	}
 
 	// 3. 创建模板
@@ -179,11 +191,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("获取文件上传链接失败: %v\n", err)
 	} else {
-		url := "-"
-		if fileUpload.URL != nil {
-			url = *fileUpload.URL
-		}
-		fmt.Printf("文件是否已存在: %v, 上传地址: %s\n", fileUpload.Present, url)
+		fmt.Printf("文件是否已存在: %v, 已获得上传地址: %v\n", fileUpload.Present, fileUpload.URL != nil)
 	}
 
 	// 11. 启动模板构建（StartTemplateBuild）

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -776,22 +776,112 @@ func TestGetInjections(t *testing.T) {
 
 func TestUpdateInjections(t *testing.T) {
 	ruleID := "rule-1"
+	headers := map[string]string{"Authorization": "Bearer token"}
 	mock := &mockAPI{
 		updateSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
-			if len(body.Injections) != 1 {
-				t.Fatalf("expected 1 injection, got %d", len(body.Injections))
+			if sandboxID != "sb-123" {
+				t.Fatalf("unexpected sandbox ID: %s", sandboxID)
+			}
+			if len(body.Injections) != 2 {
+				t.Fatalf("expected 2 injections, got %d", len(body.Injections))
 			}
 			byID, err := body.Injections[0].AsInjectionByID()
 			if err != nil || byID.ID != ruleID {
 				t.Fatalf("unexpected injection: %+v, err: %v", byID, err)
+			}
+			httpInjection, err := body.Injections[1].AsHTTPInjection()
+			if err != nil || httpInjection.BaseURL != "https://api.example.com" || httpInjection.Headers == nil || !maps.Equal(*httpInjection.Headers, headers) {
+				t.Fatalf("unexpected HTTP injection: %+v, err: %v", httpInjection, err)
 			}
 			return &apis.UpdateSandboxInjectionsResponse{HTTPResponse: httpResponse(204)}, nil
 		},
 	}
 	c := newTestClient(mock)
 	sb := newTestSandbox(c, "sb-123")
-	if err := sb.UpdateInjections(context.Background(), []SandboxInjectionSpec{{ByID: &ruleID}}); err != nil {
+	if err := sb.UpdateInjections(context.Background(), []SandboxInjectionSpec{
+		{ByID: &ruleID},
+		{HTTP: &HTTPInjection{BaseURL: "https://api.example.com", Headers: &headers}},
+	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateInjectionsClearsAllInjections(t *testing.T) {
+	mock := &mockAPI{
+		updateSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+			if body.Injections == nil || len(body.Injections) != 0 {
+				t.Fatalf("expected a non-nil empty injections list, got %#v", body.Injections)
+			}
+			return &apis.UpdateSandboxInjectionsResponse{HTTPResponse: httpResponse(204)}, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb := newTestSandbox(c, "sb-123")
+	if err := sb.UpdateInjections(context.Background(), []SandboxInjectionSpec{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetInjectionsErrors(t *testing.T) {
+	t.Run("transport", func(t *testing.T) {
+		mock := &mockAPI{
+			getSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxInjectionsResponse, error) {
+				return nil, errors.New("network error")
+			},
+		}
+		_, err := newTestSandbox(newTestClient(mock), "sb-123").GetInjections(context.Background())
+		if err == nil || err.Error() != "network error" {
+			t.Fatalf("expected transport error, got %v", err)
+		}
+	})
+
+	t.Run("api", func(t *testing.T) {
+		mock := &mockAPI{
+			getSandboxInjectionsFn: func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxInjectionsResponse, error) {
+				return &apis.GetSandboxInjectionsResponse{
+					HTTPResponse: httpResponse(404),
+					Body:         []byte(`{"message":"sandbox not found"}`),
+				}, nil
+			},
+		}
+		_, err := newTestSandbox(newTestClient(mock), "sb-404").GetInjections(context.Background())
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != 404 {
+			t.Fatalf("expected 404 API error, got %v", err)
+		}
+	})
+}
+
+func TestUpdateInjectionsErrors(t *testing.T) {
+	ruleID := "rule-1"
+	tests := []struct {
+		name string
+		fn   func(context.Context, apis.SandboxID, apis.UpdateSandboxInjectionsJSONRequestBody, ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error)
+	}{
+		{
+			name: "transport",
+			fn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+				return nil, errors.New("network error")
+			},
+		},
+		{
+			name: "api",
+			fn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxInjectionsJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxInjectionsResponse, error) {
+				return &apis.UpdateSandboxInjectionsResponse{
+					HTTPResponse: httpResponse(409),
+					Body:         []byte(`{"message":"sandbox is not running"}`),
+				}, nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockAPI{updateSandboxInjectionsFn: tt.fn}
+			err := newTestSandbox(newTestClient(mock), "sb-123").UpdateInjections(context.Background(), []SandboxInjectionSpec{{ByID: &ruleID}})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 
@@ -808,6 +898,38 @@ func TestUpdateGitHubToken(t *testing.T) {
 	sb := newTestSandbox(c, "sb-123")
 	if err := sb.UpdateGitHubToken(context.Background(), "github-token"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateGitHubTokenErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(context.Context, apis.SandboxID, apis.UpdateSandboxGithubTokenJSONRequestBody, ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error)
+	}{
+		{
+			name: "transport",
+			fn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxGithubTokenJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error) {
+				return nil, errors.New("network error")
+			},
+		},
+		{
+			name: "api",
+			fn: func(ctx context.Context, sandboxID apis.SandboxID, body apis.UpdateSandboxGithubTokenJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.UpdateSandboxGithubTokenResponse, error) {
+				return &apis.UpdateSandboxGithubTokenResponse{
+					HTTPResponse: httpResponse(400),
+					Body:         []byte(`{"message":"invalid token"}`),
+				}, nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockAPI{updateSandboxGithubTokenFn: tt.fn}
+			err := newTestSandbox(newTestClient(mock), "sb-123").UpdateGitHubToken(context.Background(), "github-token")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 

--- a/sandbox/types_injection_rule_test.go
+++ b/sandbox/types_injection_rule_test.go
@@ -4,10 +4,111 @@ package sandbox
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/qiniu/go-sdk/v7/sandbox/internal/apis"
 )
+
+func TestSandboxInjectionSpecToAPISupportsAllTypes(t *testing.T) {
+	value := "secret"
+	headers := map[string]string{"Authorization": "Bearer secret"}
+	tests := []struct {
+		name string
+		spec SandboxInjectionSpec
+		want string
+	}{
+		{name: "by ID", spec: SandboxInjectionSpec{ByID: &value}, want: string(apis.ID)},
+		{name: "OpenAI", spec: SandboxInjectionSpec{OpenAI: &OpenAIInjection{APIKey: &value}}, want: string(apis.Openai)},
+		{name: "Anthropic", spec: SandboxInjectionSpec{Anthropic: &AnthropicInjection{APIKey: &value}}, want: string(apis.Anthropic)},
+		{name: "Gemini", spec: SandboxInjectionSpec{Gemini: &GeminiInjection{APIKey: &value}}, want: string(apis.Gemini)},
+		{name: "Qiniu", spec: SandboxInjectionSpec{Qiniu: &QiniuInjection{APIKey: &value}}, want: string(apis.Qiniu)},
+		{name: "GitHub", spec: SandboxInjectionSpec{Github: &GithubInjection{Token: &value}}, want: string(apis.Github)},
+		{name: "HTTP", spec: SandboxInjectionSpec{HTTP: &HTTPInjection{BaseURL: "https://example.com", Headers: &headers}}, want: string(apis.HTTP)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sandboxInjectionSpecToAPI(tt.spec)
+			if err != nil {
+				t.Fatalf("sandboxInjectionSpecToAPI() error = %v", err)
+			}
+			discriminator, err := got.Discriminator()
+			if err != nil {
+				t.Fatalf("Discriminator() error = %v", err)
+			}
+			if discriminator != tt.want {
+				t.Fatalf("Discriminator() = %q, want %q", discriminator, tt.want)
+			}
+		})
+	}
+}
+
+func TestSandboxInjectionSpecToAPIRequiresExactlyOneType(t *testing.T) {
+	value := "secret"
+	tests := []struct {
+		name string
+		spec SandboxInjectionSpec
+		want string
+	}{
+		{name: "none", spec: SandboxInjectionSpec{}, want: "got none"},
+		{name: "multiple", spec: SandboxInjectionSpec{ByID: &value, Github: &GithubInjection{Token: &value}}, want: "got 2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sandboxInjectionSpecToAPI(tt.spec)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("sandboxInjectionSpecToAPI() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaskedSandboxInjectionFromAPISupportsAllTypes(t *testing.T) {
+	value := "masked"
+	headers := map[string]string{"Authorization": "Bear****"}
+	tests := []struct {
+		name  string
+		build func(*apis.SandboxInjection) error
+		check func(MaskedSandboxInjection) bool
+	}{
+		{name: "by ID", build: func(v *apis.SandboxInjection) error {
+			return v.FromInjectionByID(apis.InjectionByID{ID: value, Type: apis.ID})
+		}, check: func(v MaskedSandboxInjection) bool { return v.ByID != nil }},
+		{name: "OpenAI", build: func(v *apis.SandboxInjection) error {
+			return v.FromOpenaiInjection(apis.OpenaiInjection{APIKey: &value, Type: apis.Openai})
+		}, check: func(v MaskedSandboxInjection) bool { return v.OpenAI != nil }},
+		{name: "Anthropic", build: func(v *apis.SandboxInjection) error {
+			return v.FromAnthropicInjection(apis.AnthropicInjection{APIKey: &value, Type: apis.Anthropic})
+		}, check: func(v MaskedSandboxInjection) bool { return v.Anthropic != nil }},
+		{name: "Gemini", build: func(v *apis.SandboxInjection) error {
+			return v.FromGeminiInjection(apis.GeminiInjection{APIKey: &value, Type: apis.Gemini})
+		}, check: func(v MaskedSandboxInjection) bool { return v.Gemini != nil }},
+		{name: "Qiniu", build: func(v *apis.SandboxInjection) error {
+			return v.FromQiniuInjection(apis.QiniuInjection{APIKey: &value, Type: apis.Qiniu})
+		}, check: func(v MaskedSandboxInjection) bool { return v.Qiniu != nil }},
+		{name: "GitHub", build: func(v *apis.SandboxInjection) error {
+			return v.FromGithubInjection(apis.GithubInjection{Token: &value, Type: apis.Github})
+		}, check: func(v MaskedSandboxInjection) bool { return v.Github != nil }},
+		{name: "HTTP", build: func(v *apis.SandboxInjection) error {
+			return v.FromHTTPInjection(apis.HTTPInjection{BaseURL: "https://example.com", Headers: &headers, Type: apis.HTTP})
+		}, check: func(v MaskedSandboxInjection) bool { return v.HTTP != nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var apiInjection apis.SandboxInjection
+			if err := tt.build(&apiInjection); err != nil {
+				t.Fatalf("build API injection: %v", err)
+			}
+			got, err := maskedSandboxInjectionFromAPI(apiInjection)
+			if err != nil {
+				t.Fatalf("maskedSandboxInjectionFromAPI() error = %v", err)
+			}
+			if !tt.check(got) {
+				t.Fatalf("maskedSandboxInjectionFromAPI() returned wrong variant: %+v", got)
+			}
+		})
+	}
+}
 
 func TestInjectionSpecToAPIPreservesMatchConditions(t *testing.T) {
 	apiKey := "sk-test"


### PR DESCRIPTION
## Summary
- cover all writable and masked runtime injection variants, validation rules, empty replacement, and transport/API error paths
- extend the sandbox list, request injection, and template examples for the APIs introduced in #227
- make the template mutation example opt-in and avoid printing signed upload URLs

## Validation
- `gofmt -s -l .`
- `make staticcheck`
- `make unittest`
- `go build ./examples/sandbox_list ./examples/sandbox_request_injections ./examples/sandbox_templates`
- real Sandbox integration tests and the updated read-only/list/request-injection examples using `.env` credentials