### PR TITLE
feat(sandbox): expose default template listing

### DIFF
--- a/examples/sandbox_templates/main.go
+++ b/examples/sandbox_templates/main.go
@@ -29,8 +29,20 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	// 1. 列出所有模板
-	fmt.Println("=== 列出模板 ===")
+	// 1. 列出默认模板
+	fmt.Println("=== 列出默认模板 ===")
+	defaultTemplates, err := c.ListDefaultTemplates(ctx)
+	if err != nil {
+		log.Fatalf("列出默认模板失败: %v", err)
+	}
+	fmt.Printf("共 %d 个默认模板:\n", len(defaultTemplates))
+	for _, tmpl := range defaultTemplates {
+		fmt.Printf("  - %s (名称: %v, 构建状态: %s)\n",
+			tmpl.TemplateID, tmpl.Names, tmpl.BuildStatus)
+	}
+
+	// 2. 列出所有模板
+	fmt.Println("\n=== 列出模板 ===")
 	templates, err := c.ListTemplates(ctx, nil)
 	if err != nil {
 		log.Fatalf("列出模板失败: %v", err)
@@ -55,7 +67,7 @@ func main() {
 			tmpl.CreatedAt.Format(time.RFC3339), tmpl.UpdatedAt.Format(time.RFC3339))
 	}
 
-	// 2. 获取单个模板详情
+	// 3. 获取单个模板详情
 	if len(templates) > 0 {
 		fmt.Println("\n=== 获取模板详情 ===")
 		detail, err := c.GetTemplate(ctx, templates[0].TemplateID, nil)
@@ -81,7 +93,7 @@ func main() {
 		return
 	}
 
-	// 3. 创建模板
+	// 4. 创建模板
 	fmt.Println("\n=== 创建模板 ===")
 	cpuCount := int32(2)
 	memoryMB := int32(512)
@@ -108,7 +120,7 @@ func main() {
 		}
 	}()
 
-	// 4. 更新模板
+	// 5. 更新模板
 	fmt.Println("\n=== 更新模板 ===")
 	public := true
 	if err := c.UpdateTemplate(ctx, templateID, sandbox.UpdateTemplateParams{
@@ -118,7 +130,7 @@ func main() {
 	}
 	fmt.Println("模板已更新为公开")
 
-	// 5. 获取构建状态
+	// 6. 获取构建状态
 	fmt.Println("\n=== 获取构建状态 ===")
 	buildInfo, err := c.GetTemplateBuildStatus(ctx, templateID, buildID, nil)
 	if err != nil {
@@ -127,7 +139,7 @@ func main() {
 		fmt.Printf("构建 %s: 状态=%s, 模板=%s\n", buildInfo.BuildID, buildInfo.Status, buildInfo.TemplateID)
 	}
 
-	// 6. 获取构建日志
+	// 7. 获取构建日志
 	fmt.Println("\n=== 获取构建日志 ===")
 	buildLogs, err := c.GetTemplateBuildLogs(ctx, templateID, buildID, nil)
 	if err != nil {
@@ -148,7 +160,7 @@ func main() {
 		}
 	}
 
-	// 7. 分配模板标签（AssignTemplateTags）
+	// 8. 分配模板标签（AssignTemplateTags）
 	fmt.Println("\n=== 分配模板标签 ===")
 	tagResult, err := c.AssignTemplateTags(ctx, sandbox.ManageTagsParams{
 		Target: fmt.Sprintf("%s:%s", templateName, "v1"),
@@ -160,7 +172,7 @@ func main() {
 		fmt.Printf("标签已分配, 构建: %s, 标签: %v\n", tagResult.BuildID, tagResult.Tags)
 	}
 
-	// 8. 删除模板标签（DeleteTemplateTags）
+	// 9. 删除模板标签（DeleteTemplateTags）
 	fmt.Println("\n=== 删除模板标签 ===")
 	if err := c.DeleteTemplateTags(ctx, sandbox.DeleteTagsParams{
 		Name: templateName,
@@ -171,7 +183,7 @@ func main() {
 		fmt.Println("标签 'stable' 已删除")
 	}
 
-	// 9. 通过别名查找模板（GetTemplateByAlias）
+	// 10. 通过别名查找模板（GetTemplateByAlias）
 	fmt.Println("\n=== 通过别名查找模板 ===")
 	if len(templates) > 0 && len(templates[0].Aliases) > 0 {
 		alias := templates[0].Aliases[0]
@@ -185,7 +197,7 @@ func main() {
 		fmt.Println("没有可用的模板别名，跳过")
 	}
 
-	// 10. 获取模板文件上传链接（GetTemplateFiles）
+	// 11. 获取模板文件上传链接（GetTemplateFiles）
 	fmt.Println("\n=== 获取模板文件上传链接 ===")
 	fileUpload, err := c.GetTemplateFiles(ctx, templateID, "example-hash-value")
 	if err != nil {
@@ -194,7 +206,7 @@ func main() {
 		fmt.Printf("文件是否已存在: %v, 已获得上传地址: %v\n", fileUpload.Present, fileUpload.URL != nil)
 	}
 
-	// 11. 启动模板构建（StartTemplateBuild）
+	// 12. 启动模板构建（StartTemplateBuild）
 	fmt.Println("\n=== 启动模板构建 ===")
 	fromImage := "ubuntu:latest"
 	if err := c.StartTemplateBuild(ctx, templateID, buildID, sandbox.StartTemplateBuildParams{
@@ -205,7 +217,7 @@ func main() {
 		fmt.Println("构建已启动")
 	}
 
-	// 12. 等待构建完成（WaitForBuild）
+	// 13. 等待构建完成（WaitForBuild）
 	fmt.Println("\n=== 等待构建完成 ===")
 	finalBuild, err := c.WaitForBuild(ctx, templateID, buildID, sandbox.WithPollInterval(3*time.Second))
 	if err != nil {
@@ -214,5 +226,5 @@ func main() {
 		fmt.Printf("构建已完成: %s (状态: %s)\n", finalBuild.BuildID, finalBuild.Status)
 	}
 
-	// 13. 删除模板（通过 defer 执行）
+	// 14. 删除模板（通过 defer 执行）
 }

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -36,6 +36,7 @@ type mockAPI struct {
 	getSandboxMetricsFn        func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxMetricsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxMetricsResponse, error)
 	getSandboxLogsFn           func(ctx context.Context, sandboxID apis.SandboxID, params *apis.GetSandboxLogsParams, editors ...apis.RequestEditorFn) (*apis.GetSandboxLogsResponse, error)
 	refreshSandboxFn           func(ctx context.Context, sandboxID apis.SandboxID, body apis.RefreshSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RefreshSandboxResponse, error)
+	listDefaultTemplatesFn     func(ctx context.Context, editors ...apis.RequestEditorFn) (*apis.ListDefaultTemplatesResponse, error)
 	listTemplatesFn            func(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error)
 	createTemplateV3Fn         func(ctx context.Context, body apis.CreateTemplateV3JSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateTemplateV3Response, error)
 	rebuildTemplateFn          func(ctx context.Context, templateID apis.TemplateID, body apis.RebuildTemplateJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.RebuildTemplateResponse, error)
@@ -152,7 +153,7 @@ func (m *mockAPI) GetSandboxesMetricsWithResponse(ctx context.Context, params *a
 // --- 模板操作 ---
 
 func (m *mockAPI) ListDefaultTemplatesWithResponse(ctx context.Context, editors ...apis.RequestEditorFn) (*apis.ListDefaultTemplatesResponse, error) {
-	panic("not implemented")
+	return m.listDefaultTemplatesFn(ctx, editors...)
 }
 
 func (m *mockAPI) ListTemplatesWithResponse(ctx context.Context, params *apis.ListTemplatesParams, editors ...apis.RequestEditorFn) (*apis.ListTemplatesResponse, error) {
@@ -1123,6 +1124,55 @@ func TestWaitForReadyTimeout(t *testing.T) {
 }
 
 // --- 模板测试 ---
+
+func TestListDefaultTemplates(t *testing.T) {
+	mock := &mockAPI{
+		listDefaultTemplatesFn: func(ctx context.Context, editors ...apis.RequestEditorFn) (*apis.ListDefaultTemplatesResponse, error) {
+			list := []apis.Template{
+				{TemplateID: "tmpl-default-1", Names: []string{"qiniu/code-interpreter"}},
+				{TemplateID: "tmpl-default-2"},
+			}
+			return &apis.ListDefaultTemplatesResponse{
+				JSON200:      &list,
+				HTTPResponse: httpResponse(200),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	templates, err := c.ListDefaultTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(templates) != 2 {
+		t.Errorf("expected 2 templates, got %d", len(templates))
+	}
+	if !slices.Equal(templates[0].Names, []string{"qiniu/code-interpreter"}) {
+		t.Errorf("unexpected names: %v", templates[0].Names)
+	}
+}
+
+func TestListDefaultTemplatesError(t *testing.T) {
+	mock := &mockAPI{
+		listDefaultTemplatesFn: func(ctx context.Context, editors ...apis.RequestEditorFn) (*apis.ListDefaultTemplatesResponse, error) {
+			return &apis.ListDefaultTemplatesResponse{
+				HTTPResponse: httpResponse(401),
+				Body:         []byte(`{"message":"unauthorized"}`),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.ListDefaultTemplates(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 401 {
+		t.Errorf("expected status 401, got %d", apiErr.StatusCode)
+	}
+}
 
 func TestListTemplates(t *testing.T) {
 	mock := &mockAPI{

--- a/sandbox/doc.go
+++ b/sandbox/doc.go
@@ -115,7 +115,7 @@
 //
 // Client 提供模板的完整生命周期管理:
 //
-//   - [Client.ListTemplates] / [Client.GetTemplate]: 列出和查询模板
+//   - [Client.ListDefaultTemplates] / [Client.ListTemplates] / [Client.GetTemplate]: 列出和查询模板
 //   - [Client.CreateTemplate]: 创建模板（返回 templateID 和 buildID）
 //   - [Client.RebuildTemplate]: 在已有模板上创建新的 waiting build（返回新 buildID）
 //   - [Client.UpdateTemplate] / [Client.DeleteTemplate]: 更新和删除模板

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -48,6 +48,21 @@ func TestIntegrationListTemplates(t *testing.T) {
 	}
 }
 
+func TestIntegrationListDefaultTemplates(t *testing.T) {
+	c := testClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	templates, err := c.ListDefaultTemplates(ctx)
+	if err != nil {
+		t.Fatalf("ListDefaultTemplates 失败: %v", err)
+	}
+	t.Logf("共 %d 个默认模板", len(templates))
+	for _, tmpl := range templates {
+		t.Logf("  - %s (buildStatus=%s)", tmpl.TemplateID, tmpl.BuildStatus)
+	}
+}
+
 func TestIntegrationListSandboxes(t *testing.T) {
 	c := testClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/sandbox/template.go
+++ b/sandbox/template.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+// ListDefaultTemplates 列出所有默认模板。
+func (c *Client) ListDefaultTemplates(ctx context.Context) ([]Template, error) {
+	resp, err := c.api.ListDefaultTemplatesWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, newAPIError(resp.HTTPResponse, resp.Body)
+	}
+	return templatesFromAPI(*resp.JSON200), nil
+}
+
 // ListTemplates 列出所有模板。
 func (c *Client) ListTemplates(ctx context.Context, params *ListTemplatesParams) ([]Template, error) {
 	resp, err := c.api.ListTemplatesWithResponse(ctx, params.toAPI())


### PR DESCRIPTION
## 变更说明

- 为 sandbox.Client 增加 ListDefaultTemplates 公开封装
- 补充成功和 API 错误路径的单元测试
- 增加真实接口集成测试，并在 sandbox_templates 示例中展示默认模板列表
- 更新 sandbox 包文档中的模板管理能力说明

## 背景

OpenAPI 和内部生成客户端已经支持 GET /default-templates，但公开 sandbox.Client 缺少对应调用入口。本 PR 补齐公开 SDK 层及配套验证。

## 验证

- gofmt -s -l .
- make staticcheck
- make unittest
- 使用根目录 .env 运行 TestIntegrationListDefaultTemplates，真实接口返回 8 个默认模板
- 使用根目录 .env 运行 go run ./examples/sandbox_templates，示例以只读模式成功完成
- git diff --check