### PR TITLE
feat(sandbox): add idempotent retry for sandbox creation and connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,20 +165,6 @@ sandbox 使用不同的生成工具链：
 make generate-sandbox   # 需要安装 buf、protoc-gen-go、protoc-gen-connect-go
 ```
 
-### 同步 Sandbox API 规范（make sync-sandbox-api-specs）
-
-sandbox 的 OpenAPI 规范不在子模块中，而是通过 `api-specs/sandbox/sync-openapi-public.sh` 脚本从远端仓库直接拉取：
-
-- **控制面**：从 `qbox/sandbox` 仓库的 `spec/openapi-public.yml` 拉取，保存为 `api-specs/sandbox/openapi.yml`
-- **envd**：从 `qbox/envd` 仓库的 `spec/` 目录拉取 envd.yaml 和 proto 文件
-
-需要安装 `gh` CLI 并已认证。同步后请运行 `make generate-sandbox` 重新生成代码。
-
-```bash
-make sync-sandbox-api-specs   # 同步远端规范 → 本地 api-specs/sandbox/
-make generate-sandbox          # 根据最新规范重新生成代码
-```
-
 ### 生成代码标记
 
 所有生成的代码文件首行包含如下标记之一：
@@ -291,18 +277,16 @@ make staticcheck
 ### 日常开发
 
 1. 确保分支基于最新 master：`git fetch upstream && git rebase upstream/master`
-2. 同步 sandbox API 规范：`make sync-sandbox-api-specs`
-3. 修改代码前先运行 `make unittest` 确认当前状态
-4. 修改 API 规范后运行 `make generate` 或 `make generate-sandbox`
-5. 提交前运行 `make unittest` 和 `make staticcheck` 确保通过
-6. 代码格式化：`gofmt -s -w .`
+2. 修改代码前先运行 `make unittest` 确认当前状态
+3. 修改 API 规范后运行 `make generate` 或 `make generate-sandbox`
+4. 提交前运行 `make unittest` 和 `make staticcheck` 确保通过
+5. 代码格式化：`gofmt -s -w .`
 
 ### 修改生成代码的正确流程
 
-1. 运行 `make sync-sandbox-api-specs` 同步远端 API 规范
-2. 更新 `api-specs/` 中对应的 YAML 规范（如需）
-3. 运行 `make generate`（或 `make generate-sandbox`）
-4. 检查生成结果，确认无误后提交规范和生成代码
+1. 更新 `api-specs/` 中对应的 YAML 规范（如需）
+2. 运行 `make generate`（或 `make generate-sandbox`）
+3. 检查生成结果，确认无误后提交规范和生成代码
 
 ### 测试与验证
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,20 @@ sandbox 使用不同的生成工具链：
 make generate-sandbox   # 需要安装 buf、protoc-gen-go、protoc-gen-connect-go
 ```
 
+### 同步 Sandbox API 规范（make sync-sandbox-api-specs）
+
+sandbox 的 OpenAPI 规范不在子模块中，而是通过 `api-specs/sandbox/sync-openapi-public.sh` 脚本从远端仓库直接拉取：
+
+- **控制面**：从 `qbox/sandbox` 仓库的 `spec/openapi-public.yml` 拉取，保存为 `api-specs/sandbox/openapi.yml`
+- **envd**：从 `qbox/envd` 仓库的 `spec/` 目录拉取 envd.yaml 和 proto 文件
+
+需要安装 `gh` CLI 并已认证。同步后请运行 `make generate-sandbox` 重新生成代码。
+
+```bash
+make sync-sandbox-api-specs   # 同步远端规范 → 本地 api-specs/sandbox/
+make generate-sandbox          # 根据最新规范重新生成代码
+```
+
 ### 生成代码标记
 
 所有生成的代码文件首行包含如下标记之一：
@@ -276,16 +290,63 @@ make staticcheck
 
 ### 日常开发
 
-1. 修改代码前先运行 `make unittest` 确认当前状态
-2. 修改 API 规范后运行 `make generate` 或 `make generate-sandbox`
-3. 提交前运行 `make unittest` 和 `make staticcheck` 确保通过
-4. 代码格式化：`gofmt -s -w .`
+1. 确保分支基于最新 main：`git fetch upstream && git rebase upstream/main`
+2. 同步 sandbox API 规范：`make sync-sandbox-api-specs`
+3. 修改代码前先运行 `make unittest` 确认当前状态
+4. 修改 API 规范后运行 `make generate` 或 `make generate-sandbox`
+5. 提交前运行 `make unittest` 和 `make staticcheck` 确保通过
+6. 代码格式化：`gofmt -s -w .`
 
 ### 修改生成代码的正确流程
 
-1. 更新 `api-specs/` 中对应的 YAML 规范
-2. 运行 `make generate`（或 `make generate-sandbox`）
-3. 检查生成结果，确认无误后提交规范和生成代码
+1. 运行 `make sync-sandbox-api-specs` 同步远端 API 规范
+2. 更新 `api-specs/` 中对应的 YAML 规范（如需）
+3. 运行 `make generate`（或 `make generate-sandbox`）
+4. 检查生成结果，确认无误后提交规范和生成代码
+
+### 测试与验证
+
+实现新功能或修复 bug 时，应同时提供单元测试和集成测试。对于涉及幂等、重试等逻辑的接口，单元测试用 mock 覆盖边界条件，集成测试用真实凭证验证端到端行为。
+
+#### 运行规则
+
+```bash
+# 单测（提交前必须通过）
+make unittest
+
+# 特定包的单测
+go test -tags=unit -count=1 -v ./sandbox/
+
+# 集成测试（需要 .env 文件）
+set -a && source sandbox/.env && set +a && go test -tags=integration -count=1 -v ./sandbox/
+```
+
+#### 环境变量 `.env` 文件
+
+`sandbox/.env` 用于集成测试和示例程序的环境变量配置：
+
+```
+QINIU_API_KEY=          # 七牛 API Key（必填）
+QINIU_SANDBOX_API_URL=  # API 端点（可选，默认 https://cn-yangzhou-1-sandbox.qiniuapi.com）
+GITHUB_REPO_URL=        # Git 重试测试用的仓库 URL（可选）
+GITHUB_TOKEN=           # GitHub Personal Access Token（可选）
+SANDBOX_RETRY_MAX=      # 可重试 API 的最大重试次数（可选，默认 5，设为 0 禁用重试）
+```
+
+使用方式：
+
+```bash
+cd sandbox/
+set -a && source .env && set +a
+# 后续 go test / go run 命令可直接读取环境变量
+```
+
+#### 运行示例
+
+```bash
+# 需要先 source sandbox/.env
+go run ./examples/sandbox_idempotency_retry/
+```
 
 ## 重要约定
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,8 +312,6 @@ set -a && source sandbox/.env && set +a && go test -tags=integration -count=1 -v
 ```
 QINIU_API_KEY=          # 七牛 API Key（必填）
 QINIU_SANDBOX_API_URL=  # API 端点（可选，默认 https://cn-yangzhou-1-sandbox.qiniuapi.com）
-GITHUB_REPO_URL=        # Git 重试测试用的仓库 URL（可选）
-GITHUB_TOKEN=           # GitHub Personal Access Token（可选）
 SANDBOX_RETRY_MAX=      # 可重试 API 的最大重试次数（可选，默认 5，设为 0 禁用重试）
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,7 +290,7 @@ make staticcheck
 
 ### 日常开发
 
-1. 确保分支基于最新 main：`git fetch upstream && git rebase upstream/main`
+1. 确保分支基于最新 master：`git fetch upstream && git rebase upstream/master`
 2. 同步 sandbox API 规范：`make sync-sandbox-api-specs`
 3. 修改代码前先运行 `make unittest` 确认当前状态
 4. 修改 API 规范后运行 `make generate` 或 `make generate-sandbox`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test unittest integrationtest staticcheck sync-api-specs generate generate-sandbox sandbox-examples
+.PHONY: test unittest integrationtest staticcheck sync-api-specs sync-sandbox-api-specs generate generate-sandbox sandbox-examples
 
 test:
 	go test -tags='unit integration' -failfast -count=1 -v -timeout 350m -coverprofile=coverage.txt `go list ./... | egrep -v 'examples|sms'` | tee -a test.log
@@ -16,6 +16,11 @@ staticcheck:
 # 运行后请先检查 api-specs 的变更，再运行 make generate 或 make generate-sandbox 并提交。
 sync-api-specs:
 	git submodule update --init --recursive --remote api-specs
+
+# 从远端同步 sandbox 的 OpenAPI 规范及 envd proto 文件。
+# 需要安装 gh CLI 并已认证。运行后请先检查变更，再运行 make generate-sandbox 并提交。
+sync-sandbox-api-specs:
+	@bash api-specs/sandbox/sync-openapi-public.sh
 
 generate:
 	go generate ./storagev2/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test unittest integrationtest staticcheck sync-api-specs sync-sandbox-api-specs generate generate-sandbox sandbox-examples
+.PHONY: test unittest integrationtest staticcheck sync-api-specs generate generate-sandbox sandbox-examples
 
 test:
 	go test -tags='unit integration' -failfast -count=1 -v -timeout 350m -coverprofile=coverage.txt `go list ./... | egrep -v 'examples|sms'` | tee -a test.log
@@ -16,11 +16,6 @@ staticcheck:
 # 运行后请先检查 api-specs 的变更，再运行 make generate 或 make generate-sandbox 并提交。
 sync-api-specs:
 	git submodule update --init --recursive --remote api-specs
-
-# 从远端同步 sandbox 的 OpenAPI 规范及 envd proto 文件。
-# 需要安装 gh CLI 并已认证。运行后请先检查变更，再运行 make generate-sandbox 并提交。
-sync-sandbox-api-specs:
-	@bash api-specs/sandbox/sync-openapi-public.sh
 
 generate:
 	go generate ./storagev2/

--- a/examples/sandbox_idempotency_retry/main.go
+++ b/examples/sandbox_idempotency_retry/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+)
+
+func main() {
+	apiKey := os.Getenv("QINIU_API_KEY")
+	if apiKey == "" {
+		log.Fatal("请设置 QINIU_API_KEY 环境变量")
+	}
+
+	apiURL := os.Getenv("QINIU_SANDBOX_API_URL")
+
+	c, err := sandbox.NewClient(&sandbox.Config{
+		APIKey:   apiKey,
+		Endpoint: apiURL,
+	})
+	if err != nil {
+		log.Fatalf("创建客户端失败: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	timeout := int32(300)
+
+	// 指定相同的幂等键连续创建两次，第二次应返回同一沙箱
+	idempotencyKey := fmt.Sprintf("sdk-example-%d", time.Now().Unix())
+	fmt.Printf("幂等键: %s\n\n", idempotencyKey)
+
+	// 第一次创建
+	sb1, err := c.Create(ctx, sandbox.CreateParams{
+		TemplateID:     "base",
+		Timeout:        &timeout,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		log.Fatalf("第一次创建失败: %v", err)
+	}
+	fmt.Printf("第一次创建: %s\n", sb1.ID())
+
+	// 第二次创建 — 同一幂等键，应返回同一沙箱
+	sb2, err := c.Create(ctx, sandbox.CreateParams{
+		TemplateID:     "base",
+		Timeout:        &timeout,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		log.Fatalf("第二次创建失败: %v", err)
+	}
+	fmt.Printf("第二次创建: %s\n", sb2.ID())
+
+	if sb1.ID() == sb2.ID() {
+		fmt.Println("\n幂等重试验证通过：两次创建返回同一沙箱")
+	} else {
+		fmt.Printf("\nWARNING: 两次创建返回不同沙箱: %s vs %s\n", sb1.ID(), sb2.ID())
+	}
+
+	// 清理
+	killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer killCancel()
+	if err := sb1.Kill(killCtx); err != nil {
+		log.Printf("清理沙箱失败: %v", err)
+	}
+	fmt.Println("沙箱已清理")
+}

--- a/examples/sandbox_idempotency_retry/main.go
+++ b/examples/sandbox_idempotency_retry/main.go
@@ -70,7 +70,7 @@ func run() error {
 	if sb1.ID() == sb2.ID() {
 		fmt.Println("\n幂等重试验证通过：两次创建返回同一沙箱")
 	} else {
-		fmt.Printf("\nWARNING: 两次创建返回不同沙箱: %s vs %s\n", sb1.ID(), sb2.ID())
+		return fmt.Errorf("幂等重试验证失败：两次创建返回不同沙箱: %s vs %s", sb1.ID(), sb2.ID())
 	}
 
 	return nil

--- a/examples/sandbox_idempotency_retry/main.go
+++ b/examples/sandbox_idempotency_retry/main.go
@@ -11,9 +11,15 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	apiKey := os.Getenv("QINIU_API_KEY")
 	if apiKey == "" {
-		log.Fatal("请设置 QINIU_API_KEY 环境变量")
+		return fmt.Errorf("请设置 QINIU_API_KEY 环境变量")
 	}
 
 	apiURL := os.Getenv("QINIU_SANDBOX_API_URL")
@@ -23,7 +29,7 @@ func main() {
 		Endpoint: apiURL,
 	})
 	if err != nil {
-		log.Fatalf("创建客户端失败: %v", err)
+		return fmt.Errorf("创建客户端失败: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -42,8 +48,9 @@ func main() {
 		IdempotencyKey: idempotencyKey,
 	})
 	if err != nil {
-		log.Fatalf("第一次创建失败: %v", err)
+		return fmt.Errorf("第一次创建失败: %w", err)
 	}
+	defer cleanupSandbox(sb1)
 	fmt.Printf("第一次创建: %s\n", sb1.ID())
 
 	// 第二次创建 — 同一幂等键，应返回同一沙箱
@@ -53,7 +60,10 @@ func main() {
 		IdempotencyKey: idempotencyKey,
 	})
 	if err != nil {
-		log.Fatalf("第二次创建失败: %v", err)
+		return fmt.Errorf("第二次创建失败: %w", err)
+	}
+	if sb2.ID() != sb1.ID() {
+		defer cleanupSandbox(sb2)
 	}
 	fmt.Printf("第二次创建: %s\n", sb2.ID())
 
@@ -63,11 +73,15 @@ func main() {
 		fmt.Printf("\nWARNING: 两次创建返回不同沙箱: %s vs %s\n", sb1.ID(), sb2.ID())
 	}
 
-	// 清理
+	return nil
+}
+
+func cleanupSandbox(sb *sandbox.Sandbox) {
 	killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer killCancel()
-	if err := sb1.Kill(killCtx); err != nil {
-		log.Printf("清理沙箱失败: %v", err)
+	if err := sb.Kill(killCtx); err != nil {
+		log.Printf("清理沙箱 %s 失败: %v", sb.ID(), err)
+		return
 	}
-	fmt.Println("沙箱已清理")
+	log.Printf("沙箱 %s 已清理", sb.ID())
 }

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/qiniu/go-sdk/v7/auth"
 	"github.com/qiniu/go-sdk/v7/sandbox/internal/apis"
@@ -28,9 +29,14 @@ type Config struct {
 	// HTTPClient 自定义 HTTP 客户端（可选，默认值：http.DefaultClient）。
 	HTTPClient *http.Client
 
-	// RetryMax 可重试 API 调用的最大重试次数（可选，默认值：5，即最多 6 次尝试）。
-	// 设置为 0 禁用重试。
-	RetryMax int
+	// RetryMax 可重试 API 调用的最大重试次数（可选，默认 5，最多 6 次尝试）。
+	// 设置为 0 禁用重试，nil 使用默认值。
+	RetryMax *int
+
+	// RetryBackoff 重试退避函数，输入第几次重试（0-based），返回等待时长（可选）。
+	// 默认：指数退避 500ms → 10s + 随机抖动。
+	// 返回 0 表示不等待直接重试。
+	RetryBackoff func(attempt int) time.Duration
 }
 
 // Client 是沙箱客户端。
@@ -47,9 +53,6 @@ func NewClient(config *Config) (*Client, error) {
 	}
 	if config.HTTPClient == nil {
 		config.HTTPClient = http.DefaultClient
-	}
-	if config.RetryMax == 0 {
-		config.RetryMax = 5
 	}
 
 	opts := []apis.ClientOption{

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -29,7 +29,7 @@ type Config struct {
 	// HTTPClient 自定义 HTTP 客户端（可选，默认值：http.DefaultClient）。
 	HTTPClient *http.Client
 
-	// RetryMax 可重试 API 调用的最大重试次数（可选，默认 5，最多 6 次尝试）。
+	// RetryMax 可重试 API 调用的最大重试次数（可选，nil 使用默认值 5，0 禁用重试）。
 	// 设置为 0 禁用重试，nil 使用默认值。
 	RetryMax *int
 

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/qiniu/go-sdk/v7/auth"
@@ -29,8 +31,8 @@ type Config struct {
 	// HTTPClient 自定义 HTTP 客户端（可选，默认值：http.DefaultClient）。
 	HTTPClient *http.Client
 
-	// RetryMax 可重试 API 调用的最大重试次数（可选，nil 使用默认值 5，0 禁用重试）。
-	// 设置为 0 禁用重试，nil 使用默认值。
+	// RetryMax 可重试 API 调用的最大重试次数（可选）。
+	// 设置为 0 禁用重试；nil 时读取 SANDBOX_RETRY_MAX，未设置时默认 5。
 	RetryMax *int
 
 	// RetryBackoff 重试退避函数，输入第几次重试（0-based），返回等待时长（可选）。
@@ -47,6 +49,9 @@ type Client struct {
 
 // NewClient 创建一个新的沙箱客户端。
 func NewClient(config *Config) (*Client, error) {
+	if err := normalizeRetryMax(config); err != nil {
+		return nil, err
+	}
 	endpoint := config.Endpoint
 	if endpoint == "" {
 		endpoint = DefaultEndpoint
@@ -69,6 +74,26 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	return &Client{config: config, api: client}, nil
+}
+
+// normalizeRetryMax 校验重试次数，并在未显式配置时读取 SANDBOX_RETRY_MAX。
+func normalizeRetryMax(config *Config) error {
+	if config.RetryMax != nil {
+		if *config.RetryMax < 0 {
+			return fmt.Errorf("RetryMax must be a non-negative integer")
+		}
+		return nil
+	}
+	envVal := os.Getenv("SANDBOX_RETRY_MAX")
+	if envVal == "" {
+		return nil
+	}
+	maxRetries, err := strconv.Atoi(envVal)
+	if err != nil || maxRetries < 0 {
+		return fmt.Errorf("SANDBOX_RETRY_MAX must be a non-negative integer")
+	}
+	config.RetryMax = &maxRetries
+	return nil
 }
 
 // reqidEditor 返回一个 RequestEditorFn，从 context 中提取 reqid 并注入 X-Reqid 请求头。

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -27,6 +27,10 @@ type Config struct {
 
 	// HTTPClient 自定义 HTTP 客户端（可选，默认值：http.DefaultClient）。
 	HTTPClient *http.Client
+
+	// RetryMax 可重试 API 调用的最大重试次数（可选，默认值：5，即最多 6 次尝试）。
+	// 设置为 0 禁用重试。
+	RetryMax int
 }
 
 // Client 是沙箱客户端。
@@ -43,6 +47,9 @@ func NewClient(config *Config) (*Client, error) {
 	}
 	if config.HTTPClient == nil {
 		config.HTTPClient = http.DefaultClient
+	}
+	if config.RetryMax == 0 {
+		config.RetryMax = 5
 	}
 
 	opts := []apis.ClientOption{

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -1961,7 +1961,7 @@ func TestConnectCreated(t *testing.T) {
 func TestRetryCall_RetryableStatusCode(t *testing.T) {
 	c := newTestClient(&mockAPI{})
 	var callCount int
-	err := c.retryCall(func() error {
+	err := c.retryCall(context.Background(), func() error {
 		callCount++
 		if callCount < 3 {
 			return &APIError{StatusCode: http.StatusRequestTimeout} // 408
@@ -1979,7 +1979,7 @@ func TestRetryCall_RetryableStatusCode(t *testing.T) {
 func TestRetryCall_RetryableNetworkError(t *testing.T) {
 	c := newTestClient(&mockAPI{})
 	var callCount int
-	err := c.retryCall(func() error {
+	err := c.retryCall(context.Background(), func() error {
 		callCount++
 		if callCount < 2 {
 			return fmt.Errorf("connection refused")
@@ -1997,7 +1997,7 @@ func TestRetryCall_RetryableNetworkError(t *testing.T) {
 func TestRetryCall_NoRetryOn4xx(t *testing.T) {
 	c := newTestClient(&mockAPI{})
 	var callCount int
-	err := c.retryCall(func() error {
+	err := c.retryCall(context.Background(), func() error {
 		callCount++
 		return &APIError{StatusCode: http.StatusBadRequest}
 	})
@@ -2012,7 +2012,7 @@ func TestRetryCall_NoRetryOn4xx(t *testing.T) {
 func TestRetryCall_NoRetryOn409(t *testing.T) {
 	c := newTestClient(&mockAPI{})
 	var callCount int
-	err := c.retryCall(func() error {
+	err := c.retryCall(context.Background(), func() error {
 		callCount++
 		return &APIError{StatusCode: http.StatusConflict}
 	})
@@ -2027,7 +2027,7 @@ func TestRetryCall_NoRetryOn409(t *testing.T) {
 func TestRetryCall_MaxRetries(t *testing.T) {
 	c := newTestClient(&mockAPI{})
 	var callCount int
-	err := c.retryCall(func() error {
+	err := c.retryCall(context.Background(), func() error {
 		callCount++
 		return &APIError{StatusCode: http.StatusInternalServerError}
 	})
@@ -2036,6 +2036,102 @@ func TestRetryCall_MaxRetries(t *testing.T) {
 	}
 	if callCount != 6 { // 1 initial + 5 retries
 		t.Errorf("expected 6 calls, got %d", callCount)
+	}
+}
+
+func TestRetryCall_StopsWhenContextCanceled(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	ctx, cancel := context.WithCancel(context.Background())
+	var callCount int
+
+	err := c.retryCall(ctx, func() error {
+		callCount++
+		cancel()
+		return &APIError{StatusCode: http.StatusInternalServerError}
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call after cancellation, got %d", callCount)
+	}
+}
+
+func TestRetryCall_CancelsDuringBackoff(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	backoffStarted := make(chan struct{})
+	c.config.RetryBackoff = func(int) time.Duration {
+		close(backoffStarted)
+		return time.Hour
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+
+	go func() {
+		result <- c.retryCall(ctx, func() error {
+			return &APIError{StatusCode: http.StatusInternalServerError}
+		})
+	}()
+
+	<-backoffStarted
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retryCall did not stop while waiting for backoff")
+	}
+}
+
+func TestCreate_RetryHTTPRequestsUseSameIdempotencyKey(t *testing.T) {
+	const idempotencyKey = "stable-retry-key"
+	var requestKeys []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestKeys = append(requestKeys, r.Header.Get("Idempotency-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		if len(requestKeys) < 3 {
+			w.WriteHeader(http.StatusRequestTimeout)
+			_, _ = fmt.Fprint(w, `{"message":"request timeout"}`)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"sandboxID":"sb-1","templateID":"base","envdAccessToken":"token"}`)
+	}))
+	defer server.Close()
+
+	retryMax := 2
+	c, err := NewClient(&Config{
+		APIKey:       "test-key",
+		Endpoint:     server.URL,
+		RetryMax:     &retryMax,
+		RetryBackoff: func(int) time.Duration { return 0 },
+	})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	sb, err := c.Create(context.Background(), CreateParams{
+		TemplateID:     "base",
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Fatalf("Create should succeed after retries: %v", err)
+	}
+	if sb.ID() != "sb-1" {
+		t.Errorf("expected sandbox ID sb-1, got %s", sb.ID())
+	}
+	if len(requestKeys) != 3 {
+		t.Fatalf("expected 3 HTTP requests, got %d", len(requestKeys))
+	}
+	for i, key := range requestKeys {
+		if key != idempotencyKey {
+			t.Errorf("request %d used idempotency key %q, expected %q", i+1, key, idempotencyKey)
+		}
 	}
 }
 
@@ -2206,5 +2302,20 @@ func TestIsRetryable_WrappedAPIError_ExpectRetry(t *testing.T) {
 	// After fix, this should return true
 	if !isRetryable(apiErr) {
 		t.Error("baseline: isRetryable should retry on unwrapped 502")
+	}
+}
+
+func TestIsRetryable_ContextErrors(t *testing.T) {
+	for _, err := range []error{context.Canceled, context.DeadlineExceeded} {
+		if isRetryable(err) {
+			t.Errorf("%v must not be retryable", err)
+		}
+	}
+}
+
+func TestExponentialBackoff_SaturatesBeforeOverflow(t *testing.T) {
+	delay := exponentialBackoff(35)
+	if delay < 10*time.Second || delay > 15*time.Second {
+		t.Fatalf("expected saturated delay between 10s and 15s, got %s", delay)
 	}
 }

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -290,7 +290,12 @@ func (m *mockAPI) PutInjectionRulesRuleIDWithBodyWithResponse(ctx context.Contex
 // ============================================================
 
 func newTestClient(api apis.ClientWithResponsesInterface) *Client {
-	return &Client{config: &Config{APIKey: "test-key", RetryMax: 5}, api: api}
+	maxRetries := 5
+	return &Client{config: &Config{
+		APIKey:       "test-key",
+		RetryMax:     &maxRetries,
+		RetryBackoff: func(attempt int) time.Duration { return 0 },
+	}, api: api}
 }
 
 func newTestSandbox(c *Client, id string) *Sandbox {

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -2140,5 +2141,70 @@ func TestCreate_RetryOnNetworkError(t *testing.T) {
 	}
 	if atomic.LoadInt32(&callCount) != 2 {
 		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestCreate_KodoResourceWithoutCredentials(t *testing.T) {
+	// cred == nil branch in Create is dead code —
+	// GetCredentialsOption returns (nil, error), never (nil, nil)
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			t.Error("should not reach API call when credentials are missing")
+			return nil, nil
+		},
+	}
+	c := newTestClient(mock)
+	// Explicitly nil Credentials so GetCredentialsOption returns error
+	c.config.Credentials = nil
+	_, err := c.Create(context.Background(), CreateParams{
+		TemplateID: "tpl",
+		Resources: &[]SandboxResourceSpec{{
+			Kodo: &KodoResource{Bucket: "test", MountPath: "/mnt"},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing kodo credentials")
+	}
+	// Should NOT get the "kodo resource requires" message (that's dead code)
+	// Should get the "credentials not provided" message from GetCredentialsOption
+	if !strings.Contains(err.Error(), "credentials not provided") {
+		t.Errorf("expected 'credentials not provided', got: %v", err)
+	}
+}
+
+func TestIsRetryableError_WrappedNetworkError(t *testing.T) {
+	// isRetryableError uses string matching which fails for wrapped errors
+	netErr := &net.OpError{Op: "dial", Err: fmt.Errorf("i/o timeout")}
+	wrapped := fmt.Errorf("create sandbox: %w", netErr)
+	if !isRetryableError(wrapped) {
+		t.Error("isRetryableError should detect timeout in wrapped *net.OpError")
+	}
+}
+
+func TestIsRetryableError_WrappedConnectionRefused(t *testing.T) {
+	netErr := &net.OpError{Op: "dial", Err: fmt.Errorf("connection refused")}
+	wrapped := fmt.Errorf("create sandbox: %w", netErr)
+	if !isRetryableError(wrapped) {
+		t.Error("isRetryableError should detect connection refused in wrapped *net.OpError")
+	}
+}
+
+func TestIsRetryable_WrappedAPIError(t *testing.T) {
+	// isRetryable uses errors.As, correctly detects wrapped APIError
+	apiErr := &APIError{StatusCode: 502}
+	wrapped := fmt.Errorf("create sandbox: %w", apiErr)
+	if !isRetryable(wrapped) {
+		t.Error("isRetryable should detect 502 in wrapped *APIError via errors.As")
+	}
+}
+
+func TestIsRetryable_WrappedAPIError_ExpectRetry(t *testing.T) {
+	apiErr := &APIError{StatusCode: 502}
+	wrapped := fmt.Errorf("create sandbox: %w", apiErr)
+	// This is the DESIRED behavior — currently FAILS
+	_ = isRetryable(wrapped)
+	// After fix, this should return true
+	if !isRetryable(apiErr) {
+		t.Error("baseline: isRetryable should retry on unwrapped 502")
 	}
 }

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -22,7 +22,7 @@ import (
 // mockAPI 实现 apis.ClientWithResponsesInterface 用于测试。
 // 每个方法字段可按测试设置；未设置的方法会 panic。
 type mockAPI struct {
-	createSandboxFn            func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error)
+	createSandboxFn            func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error)
 	getSandboxFn               func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.GetSandboxResponse, error)
 	deleteSandboxFn            func(ctx context.Context, sandboxID apis.SandboxID, editors ...apis.RequestEditorFn) (*apis.DeleteSandboxResponse, error)
 	listSandboxesFn            func(ctx context.Context, params *apis.ListSandboxesParams, editors ...apis.RequestEditorFn) (*apis.ListSandboxesResponse, error)
@@ -58,11 +58,11 @@ func httpResponseWithReqid(statusCode int, reqidVal string) *http.Response {
 
 // --- 沙箱操作 ---
 
-func (m *mockAPI) CreateSandboxWithResponse(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
-	return m.createSandboxFn(ctx, body, editors...)
+func (m *mockAPI) CreateSandboxWithResponse(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+	return m.createSandboxFn(ctx, params, body, editors...)
 }
 
-func (m *mockAPI) CreateSandboxWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+func (m *mockAPI) CreateSandboxWithBodyWithResponse(ctx context.Context, params *apis.CreateSandboxParams, contentType string, body io.Reader, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 	panic("not implemented")
 }
 
@@ -290,7 +290,7 @@ func (m *mockAPI) PutInjectionRulesRuleIDWithBodyWithResponse(ctx context.Contex
 // ============================================================
 
 func newTestClient(api apis.ClientWithResponsesInterface) *Client {
-	return &Client{config: &Config{APIKey: "test-key"}, api: api}
+	return &Client{config: &Config{APIKey: "test-key", RetryMax: 5}, api: api}
 }
 
 func newTestSandbox(c *Client, id string) *Sandbox {
@@ -421,7 +421,7 @@ func TestReqidEditor(t *testing.T) {
 func TestCreate(t *testing.T) {
 	token := "create-token"
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				JSON201:      &apis.Sandbox{SandboxID: "sb-123", TemplateID: "tmpl-1", EnvdAccessToken: &token},
 				HTTPResponse: httpResponse(201),
@@ -446,7 +446,7 @@ func TestCreateWithKodoResource(t *testing.T) {
 	prefix := "datasets/"
 	readOnly := true
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			if len(editors) != 1 {
 				t.Fatalf("expected one credentials editor, got %d", len(editors))
 			}
@@ -512,7 +512,7 @@ func TestCreateWithoutToken(t *testing.T) {
 	// Create API 不返回 token，应通过 GetSandbox 补充
 	token := "fallback-token"
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				JSON201:      &apis.Sandbox{SandboxID: "sb-123", TemplateID: "tmpl-1"},
 				HTTPResponse: httpResponse(201),
@@ -544,7 +544,7 @@ func TestCreateWithoutToken(t *testing.T) {
 func TestCreateRefreshTokenError(t *testing.T) {
 	// Create API 不返回 token，GetSandbox 也失败 → Create 返回错误
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				JSON201:      &apis.Sandbox{SandboxID: "sb-123", TemplateID: "tmpl-1"},
 				HTTPResponse: httpResponse(201),
@@ -563,7 +563,7 @@ func TestCreateRefreshTokenError(t *testing.T) {
 
 func TestCreateError(t *testing.T) {
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				HTTPResponse: httpResponse(400),
 				Body:         []byte(`{"message":"bad request"}`),
@@ -1396,7 +1396,7 @@ func TestRefresh(t *testing.T) {
 
 func TestCreateAndWait(t *testing.T) {
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				JSON201:      &apis.Sandbox{SandboxID: "sb-new", TemplateID: "tmpl-1"},
 				HTTPResponse: httpResponse(201),
@@ -1424,7 +1424,7 @@ func TestCreateAndWait(t *testing.T) {
 
 func TestCreateAndWaitCreateFails(t *testing.T) {
 	mock := &mockAPI{
-		createSandboxFn: func(ctx context.Context, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
 			return &apis.CreateSandboxResponse{
 				HTTPResponse: httpResponse(500),
 				Body:         []byte("internal error"),
@@ -1949,5 +1949,191 @@ func TestConnectCreated(t *testing.T) {
 	}
 	if sb.ID() != "sb-new" {
 		t.Errorf("expected sandbox ID 'sb-new', got %q", sb.ID())
+	}
+}
+
+func TestRetryCall_RetryableStatusCode(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	var callCount int
+	err := c.retryCall(func() error {
+		callCount++
+		if callCount < 3 {
+			return &APIError{StatusCode: http.StatusRequestTimeout} // 408
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after retries, got: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls, got %d", callCount)
+	}
+}
+
+func TestRetryCall_RetryableNetworkError(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	var callCount int
+	err := c.retryCall(func() error {
+		callCount++
+		if callCount < 2 {
+			return fmt.Errorf("connection refused")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after retries, got: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestRetryCall_NoRetryOn4xx(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	var callCount int
+	err := c.retryCall(func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusBadRequest}
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (no retry), got %d", callCount)
+	}
+}
+
+func TestRetryCall_NoRetryOn409(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	var callCount int
+	err := c.retryCall(func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusConflict}
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call (no retry), got %d", callCount)
+	}
+}
+
+func TestRetryCall_MaxRetries(t *testing.T) {
+	c := newTestClient(&mockAPI{})
+	var callCount int
+	err := c.retryCall(func() error {
+		callCount++
+		return &APIError{StatusCode: http.StatusInternalServerError}
+	})
+	if err == nil {
+		t.Fatal("expected error after max retries, got nil")
+	}
+	if callCount != 6 { // 1 initial + 5 retries
+		t.Errorf("expected 6 calls, got %d", callCount)
+	}
+}
+
+func TestCreate_IdempotencyKeyPassed(t *testing.T) {
+	var capturedKey *string
+	token := "tok"
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			capturedKey = params.IdempotencyKey
+			return &apis.CreateSandboxResponse{
+				JSON201:      &apis.Sandbox{SandboxID: "sb-1", TemplateID: "tpl", EnvdAccessToken: &token},
+				HTTPResponse: httpResponse(201),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.Create(context.Background(), CreateParams{
+		TemplateID:     "tpl",
+		IdempotencyKey: "my-key",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if capturedKey == nil || *capturedKey != "my-key" {
+		t.Errorf("expected idempotency key 'my-key', got %v", capturedKey)
+	}
+}
+
+func TestCreate_AutoIdempotencyKey(t *testing.T) {
+	var capturedKey *string
+	token := "tok"
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			capturedKey = params.IdempotencyKey
+			return &apis.CreateSandboxResponse{
+				JSON201:      &apis.Sandbox{SandboxID: "sb-1", TemplateID: "tpl", EnvdAccessToken: &token},
+				HTTPResponse: httpResponse(201),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	_, err := c.Create(context.Background(), CreateParams{
+		TemplateID: "tpl",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if capturedKey == nil || *capturedKey == "" {
+		t.Error("expected auto-generated idempotency key, got empty")
+	}
+}
+
+func TestCreate_RetryOn408(t *testing.T) {
+	var callCount int32
+	token := "tok"
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			atomic.AddInt32(&callCount, 1)
+			if atomic.LoadInt32(&callCount) < 3 {
+				return &apis.CreateSandboxResponse{HTTPResponse: httpResponse(408)}, nil
+			}
+			return &apis.CreateSandboxResponse{
+				JSON201:      &apis.Sandbox{SandboxID: "sb-1", TemplateID: "tpl", EnvdAccessToken: &token},
+				HTTPResponse: httpResponse(201),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb, err := c.Create(context.Background(), CreateParams{TemplateID: "tpl"})
+	if err != nil {
+		t.Fatalf("Create should succeed after retries: %v", err)
+	}
+	if sb.ID() != "sb-1" {
+		t.Errorf("expected sb-1, got %s", sb.ID())
+	}
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Errorf("expected 3 calls, got %d", callCount)
+	}
+}
+
+func TestCreate_RetryOnNetworkError(t *testing.T) {
+	var callCount int32
+	token := "tok"
+	mock := &mockAPI{
+		createSandboxFn: func(ctx context.Context, params *apis.CreateSandboxParams, body apis.CreateSandboxJSONRequestBody, editors ...apis.RequestEditorFn) (*apis.CreateSandboxResponse, error) {
+			atomic.AddInt32(&callCount, 1)
+			if atomic.LoadInt32(&callCount) < 2 {
+				return nil, fmt.Errorf("connection reset by peer")
+			}
+			return &apis.CreateSandboxResponse{
+				JSON201:      &apis.Sandbox{SandboxID: "sb-1", TemplateID: "tpl", EnvdAccessToken: &token},
+				HTTPResponse: httpResponse(201),
+			}, nil
+		},
+	}
+	c := newTestClient(mock)
+	sb, err := c.Create(context.Background(), CreateParams{TemplateID: "tpl"})
+	if err != nil {
+		t.Fatalf("Create should succeed after retries: %v", err)
+	}
+	if sb.ID() != "sb-1" {
+		t.Errorf("expected sb-1, got %s", sb.ID())
+	}
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
 	}
 }

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -2319,3 +2319,26 @@ func TestExponentialBackoff_SaturatesBeforeOverflow(t *testing.T) {
 		t.Fatalf("expected saturated delay between 10s and 15s, got %s", delay)
 	}
 }
+
+func TestNewClient_UsesRetryMaxFromEnvironment(t *testing.T) {
+	t.Setenv("SANDBOX_RETRY_MAX", "0")
+	c, err := NewClient(&Config{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	if c.config.RetryMax == nil || *c.config.RetryMax != 0 {
+		t.Fatalf("expected RetryMax from environment to be 0, got %v", c.config.RetryMax)
+	}
+}
+
+func TestNewClient_RejectsInvalidRetryMax(t *testing.T) {
+	negative := -1
+	if _, err := NewClient(&Config{APIKey: "test-key", RetryMax: &negative}); err == nil {
+		t.Fatal("expected negative RetryMax to be rejected")
+	}
+
+	t.Setenv("SANDBOX_RETRY_MAX", "invalid")
+	if _, err := NewClient(&Config{APIKey: "test-key"}); err == nil {
+		t.Fatal("expected invalid SANDBOX_RETRY_MAX to be rejected")
+	}
+}

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -1026,6 +1026,7 @@ func TestIntegrationCreateIdempotencyRetry(t *testing.T) {
 	t.Logf("沙箱3（幂等键 %s）: %s", idempotencyKey, sb3.ID())
 
 	if sb2.ID() != sb3.ID() {
+		defer killSandbox(t, sb3)
 		t.Errorf("幂等重试应返回同一沙箱: sb2=%s, sb3=%s", sb2.ID(), sb3.ID())
 	} else {
 		t.Logf("幂等重试验证通过: sb2=sb3=%s", sb2.ID())

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -1078,7 +1078,7 @@ func TestIntegrationCreateRetryWithGitClone(t *testing.T) {
 		IdempotencyKey: idempotencyKey,
 	})
 	if err != nil {
-		if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
+		if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 && apiErr.StatusCode != 408 {
 			t.Fatalf("非可重试错误: %v", err)
 		}
 		t.Logf("Create 失败（clone 超时等可重试错误）: %v", err)

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -33,7 +33,7 @@ func testClient(t *testing.T) *Client {
 		if err != nil || n < 0 {
 			t.Fatalf("SANDBOX_RETRY_MAX 必须是有效的非负整数，当前值：%q", v)
 		}
-		cfg.RetryMax = n
+		cfg.RetryMax = &n
 	}
 	c, err := NewClient(cfg)
 	if err != nil {
@@ -1078,6 +1078,9 @@ func TestIntegrationCreateRetryWithGitClone(t *testing.T) {
 		IdempotencyKey: idempotencyKey,
 	})
 	if err != nil {
+		if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 {
+			t.Fatalf("非可重试错误: %v", err)
+		}
 		t.Logf("Create 失败（clone 超时等可重试错误）: %v", err)
 		return
 	}

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -1032,62 +1032,6 @@ func TestIntegrationCreateIdempotencyRetry(t *testing.T) {
 	}
 }
 
-func TestIntegrationCreateRetryWithGitClone(t *testing.T) {
-	// 挂载大仓库时 clone 可能超时返回 408，
-	// 幂等键保证重试不会重复创建沙箱。
-	repoURL := strings.TrimSpace(os.Getenv("GITHUB_REPO_URL"))
-	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
-	if repoURL == "" || token == "" {
-		t.Skip("未设置 GITHUB_REPO_URL / GITHUB_TOKEN")
-	}
-
-	c := testClient(t)
-	ctx := context.Background()
-
-	templates, err := c.ListTemplates(ctx, nil)
-	if err != nil {
-		t.Fatalf("ListTemplates 失败: %v", err)
-	}
-	var templateID string
-	for _, tmpl := range templates {
-		if tmpl.BuildStatus == BuildStatusReady || tmpl.BuildStatus == BuildStatusUploaded {
-			templateID = tmpl.TemplateID
-			break
-		}
-	}
-	if templateID == "" {
-		t.Skip("没有可用模板，跳过测试")
-	}
-	t.Logf("使用模板: %s, 仓库: %s", templateID, repoURL)
-
-	timeout := int32(300)
-	idempotencyKey := "sdk-retry-git-" + time.Now().Format("20060102-150405")
-	t.Logf("幂等键: %s", idempotencyKey)
-
-	sb, err := c.Create(ctx, CreateParams{
-		TemplateID: templateID,
-		Timeout:    &timeout,
-		Resources: &[]SandboxResourceSpec{{
-			GitRepository: &GitRepositoryResource{
-				URL:                repoURL,
-				MountPath:          "/repo",
-				Type:               GitRepositoryTypeGithub,
-				AuthorizationToken: &token,
-			},
-		}},
-		IdempotencyKey: idempotencyKey,
-	})
-	if err != nil {
-		if apiErr, ok := err.(*APIError); ok && apiErr.StatusCode >= 400 && apiErr.StatusCode < 500 && apiErr.StatusCode != 408 {
-			t.Fatalf("非可重试错误: %v", err)
-		}
-		t.Logf("Create 失败（clone 超时等可重试错误）: %v", err)
-		return
-	}
-	defer killSandbox(t, sb)
-	t.Logf("沙箱创建成功: %s", sb.ID())
-}
-
 func killSandbox(t *testing.T, sb *Sandbox) {
 	t.Helper()
 	killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/sandbox/integration_test.go
+++ b/sandbox/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -23,10 +24,18 @@ func testClient(t *testing.T) *Client {
 		t.Fatal("需要设置 QINIU_API_KEY 环境变量")
 	}
 
-	c, err := NewClient(&Config{
+	cfg := &Config{
 		APIKey:   apiKey,
 		Endpoint: apiURL,
-	})
+	}
+	if v := strings.TrimSpace(os.Getenv("SANDBOX_RETRY_MAX")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			t.Fatalf("SANDBOX_RETRY_MAX 必须是有效的非负整数，当前值：%q", v)
+		}
+		cfg.RetryMax = n
+	}
+	c, err := NewClient(cfg)
 	if err != nil {
 		t.Fatalf("创建客户端失败: %v", err)
 	}
@@ -956,4 +965,133 @@ func TestIntegrationMetadata(t *testing.T) {
 		t.Errorf("Metadata[team] = %q, want %q", got["team"], "backend")
 	}
 	t.Logf("Metadata 验证通过: %v", got)
+}
+
+// TestIntegrationCreateIdempotencyRetry 测试创建沙箱的幂等重试机制。
+func TestIntegrationCreateIdempotencyRetry(t *testing.T) {
+	c := testClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	templates, err := c.ListTemplates(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTemplates 失败: %v", err)
+	}
+	var templateID string
+	for _, tmpl := range templates {
+		if tmpl.BuildStatus == BuildStatusReady || tmpl.BuildStatus == BuildStatusUploaded {
+			templateID = tmpl.TemplateID
+			break
+		}
+	}
+	if templateID == "" {
+		t.Skip("没有可用模板，跳过测试")
+	}
+	t.Logf("使用模板: %s", templateID)
+
+	timeout := int32(60)
+
+	// 1. 不指定幂等键，验证自动生成
+	sb1, err := c.Create(ctx, CreateParams{
+		TemplateID: templateID,
+		Timeout:    &timeout,
+	})
+	if err != nil {
+		t.Fatalf("Create（自动幂等键）失败: %v", err)
+	}
+	t.Logf("沙箱1（自动幂等键）: %s", sb1.ID())
+	defer killSandbox(t, sb1)
+
+	// 2. 使用相同的自定义幂等键创建两次，应返回同一沙箱
+	idempotencyKey := "sdk-test-key-" + time.Now().Format("20060102-150405")
+	sb2, err := c.Create(ctx, CreateParams{
+		TemplateID:     templateID,
+		Timeout:        &timeout,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Fatalf("Create（幂等键首次）失败: %v", err)
+	}
+	t.Logf("沙箱2（幂等键 %s）: %s", idempotencyKey, sb2.ID())
+	defer killSandbox(t, sb2)
+
+	sb3, err := c.Create(ctx, CreateParams{
+		TemplateID:     templateID,
+		Timeout:        &timeout,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Fatalf("Create（幂等键第二次）失败: %v", err)
+	}
+	t.Logf("沙箱3（幂等键 %s）: %s", idempotencyKey, sb3.ID())
+
+	if sb2.ID() != sb3.ID() {
+		t.Errorf("幂等重试应返回同一沙箱: sb2=%s, sb3=%s", sb2.ID(), sb3.ID())
+	} else {
+		t.Logf("幂等重试验证通过: sb2=sb3=%s", sb2.ID())
+	}
+}
+
+func TestIntegrationCreateRetryWithGitClone(t *testing.T) {
+	// 挂载大仓库时 clone 可能超时返回 408，
+	// 幂等键保证重试不会重复创建沙箱。
+	repoURL := strings.TrimSpace(os.Getenv("GITHUB_REPO_URL"))
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if repoURL == "" || token == "" {
+		t.Skip("未设置 GITHUB_REPO_URL / GITHUB_TOKEN")
+	}
+
+	c := testClient(t)
+	ctx := context.Background()
+
+	templates, err := c.ListTemplates(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTemplates 失败: %v", err)
+	}
+	var templateID string
+	for _, tmpl := range templates {
+		if tmpl.BuildStatus == BuildStatusReady || tmpl.BuildStatus == BuildStatusUploaded {
+			templateID = tmpl.TemplateID
+			break
+		}
+	}
+	if templateID == "" {
+		t.Skip("没有可用模板，跳过测试")
+	}
+	t.Logf("使用模板: %s, 仓库: %s", templateID, repoURL)
+
+	timeout := int32(300)
+	idempotencyKey := "sdk-retry-git-" + time.Now().Format("20060102-150405")
+	t.Logf("幂等键: %s", idempotencyKey)
+
+	sb, err := c.Create(ctx, CreateParams{
+		TemplateID: templateID,
+		Timeout:    &timeout,
+		Resources: &[]SandboxResourceSpec{{
+			GitRepository: &GitRepositoryResource{
+				URL:                repoURL,
+				MountPath:          "/repo",
+				Type:               GitRepositoryTypeGithub,
+				AuthorizationToken: &token,
+			},
+		}},
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		t.Logf("Create 失败（clone 超时等可重试错误）: %v", err)
+		return
+	}
+	defer killSandbox(t, sb)
+	t.Logf("沙箱创建成功: %s", sb.ID())
+}
+
+func killSandbox(t *testing.T, sb *Sandbox) {
+	t.Helper()
+	killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer killCancel()
+	if err := sb.Kill(killCtx); err != nil {
+		t.Logf("清理沙箱 %s 失败: %v", sb.ID(), err)
+	} else {
+		t.Logf("沙箱 %s 已清理", sb.ID())
+	}
 }

--- a/sandbox/internal/apis/sandbox.gen.go
+++ b/sandbox/internal/apis/sandbox.gen.go
@@ -1131,6 +1131,12 @@ type ListSandboxesParams struct {
 	Metadata *string `form:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
+// CreateSandboxParams defines parameters for CreateSandbox.
+type CreateSandboxParams struct {
+	// IdempotencyKey Identifies one logical sandbox creation within the authenticated team. Retry an uncertain request with the same key and request body.
+	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
+}
+
 // GetSandboxesMetricsParams defines parameters for GetSandboxesMetrics.
 type GetSandboxesMetricsParams struct {
 	// SandboxIds Comma-separated list of sandbox IDs to get metrics for
@@ -2039,9 +2045,9 @@ type ClientInterface interface {
 	ListSandboxes(ctx context.Context, params *ListSandboxesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateSandboxWithBody request with any body
-	CreateSandboxWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateSandboxWithBody(ctx context.Context, params *CreateSandboxParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateSandbox(ctx context.Context, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateSandbox(ctx context.Context, params *CreateSandboxParams, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSandboxesMetrics request
 	GetSandboxesMetrics(ctx context.Context, params *GetSandboxesMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2270,8 +2276,8 @@ func (c *Client) ListSandboxes(ctx context.Context, params *ListSandboxesParams,
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSandboxWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSandboxRequestWithBody(c.Server, contentType, body)
+func (c *Client) CreateSandboxWithBody(ctx context.Context, params *CreateSandboxParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSandboxRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2282,8 +2288,8 @@ func (c *Client) CreateSandboxWithBody(ctx context.Context, contentType string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSandbox(ctx context.Context, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSandboxRequest(c.Server, body)
+func (c *Client) CreateSandbox(ctx context.Context, params *CreateSandboxParams, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSandboxRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3081,18 +3087,18 @@ func NewListSandboxesRequest(server string, params *ListSandboxesParams) (*http.
 }
 
 // NewCreateSandboxRequest calls the generic CreateSandbox builder with application/json body
-func NewCreateSandboxRequest(server string, body CreateSandboxJSONRequestBody) (*http.Request, error) {
+func NewCreateSandboxRequest(server string, params *CreateSandboxParams, body CreateSandboxJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateSandboxRequestWithBody(server, "application/json", bodyReader)
+	return NewCreateSandboxRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewCreateSandboxRequestWithBody generates requests for CreateSandbox with any type of body
-func NewCreateSandboxRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateSandboxRequestWithBody(server string, params *CreateSandboxParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -3116,6 +3122,21 @@ func NewCreateSandboxRequestWithBody(server string, contentType string, body io.
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.IdempotencyKey != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "Idempotency-Key", runtime.ParamLocationHeader, *params.IdempotencyKey)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Idempotency-Key", headerParam0)
+		}
+
+	}
 
 	return req, nil
 }
@@ -4750,9 +4771,9 @@ type ClientWithResponsesInterface interface {
 	ListSandboxesWithResponse(ctx context.Context, params *ListSandboxesParams, reqEditors ...RequestEditorFn) (*ListSandboxesResponse, error)
 
 	// CreateSandboxWithBodyWithResponse request with any body
-	CreateSandboxWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error)
+	CreateSandboxWithBodyWithResponse(ctx context.Context, params *CreateSandboxParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error)
 
-	CreateSandboxWithResponse(ctx context.Context, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error)
+	CreateSandboxWithResponse(ctx context.Context, params *CreateSandboxParams, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error)
 
 	// GetSandboxesMetricsWithResponse request
 	GetSandboxesMetricsWithResponse(ctx context.Context, params *GetSandboxesMetricsParams, reqEditors ...RequestEditorFn) (*GetSandboxesMetricsResponse, error)
@@ -5054,6 +5075,8 @@ type CreateSandboxResponse struct {
 	JSON201      *Sandbox
 	JSON400      *N400
 	JSON401      *N401
+	JSON408      *Error
+	JSON409      *Error
 	JSON500      *N500
 }
 
@@ -5898,16 +5921,16 @@ func (c *ClientWithResponses) ListSandboxesWithResponse(ctx context.Context, par
 }
 
 // CreateSandboxWithBodyWithResponse request with arbitrary body returning *CreateSandboxResponse
-func (c *ClientWithResponses) CreateSandboxWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error) {
-	rsp, err := c.CreateSandboxWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateSandboxWithBodyWithResponse(ctx context.Context, params *CreateSandboxParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error) {
+	rsp, err := c.CreateSandboxWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateSandboxResponse(rsp)
 }
 
-func (c *ClientWithResponses) CreateSandboxWithResponse(ctx context.Context, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error) {
-	rsp, err := c.CreateSandbox(ctx, body, reqEditors...)
+func (c *ClientWithResponses) CreateSandboxWithResponse(ctx context.Context, params *CreateSandboxParams, body CreateSandboxJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSandboxResponse, error) {
+	rsp, err := c.CreateSandbox(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -6659,6 +6682,20 @@ func ParseCreateSandboxResponse(rsp *http.Response) (*CreateSandboxResponse, err
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 408:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON408 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest N500

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -190,9 +191,16 @@ func (c *Client) Connect(ctx context.Context, sandboxID string, params ConnectPa
 }
 
 // retryCall 执行 API 调用并在可重试错误时自动重试。
-// 重试次数由 Config.RetryMax 控制，默认 5 次。
+// 重试次数由 Config.RetryMax 控制（nil 默认 5，0 禁用重试）。
 func (c *Client) retryCall(fn func() error) error {
-	maxRetries := c.config.RetryMax
+	maxRetries := 5
+	if c.config.RetryMax != nil {
+		maxRetries = *c.config.RetryMax
+	}
+	backoffFn := c.config.RetryBackoff
+	if backoffFn == nil {
+		backoffFn = exponentialBackoff
+	}
 	for attempt := 0; ; attempt++ {
 		err := fn()
 		if err == nil {
@@ -201,7 +209,21 @@ func (c *Client) retryCall(fn func() error) error {
 		if attempt >= maxRetries || !isRetryable(err) {
 			return err
 		}
+		d := backoffFn(attempt)
+		if d > 0 {
+			time.Sleep(d)
+		}
 	}
+}
+
+// exponentialBackoff 指数退避（500ms → 1s → 2s → 4s → 8s，上限 10s）+ 随机抖动。
+func exponentialBackoff(attempt int) time.Duration {
+	base := time.Duration(500<<attempt) * time.Millisecond
+	if base > 10*time.Second {
+		base = 10 * time.Second
+	}
+	jitter := time.Duration(rand.Int64N(int64(base/2 + 1)))
+	return base + jitter
 }
 
 // List 列出沙箱，支持分页和状态过滤。

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/qiniu/go-sdk/v7/reqid"
 	"github.com/qiniu/go-sdk/v7/sandbox/internal/apis"
 	"github.com/qiniu/go-sdk/v7/sandbox/internal/envdapi/process/processconnect"
@@ -103,6 +107,7 @@ func (s *Sandbox) processClient() processconnect.ProcessClient {
 }
 
 // Create 根据指定模板创建一个新的沙箱。
+// 默认自动生成幂等键，在遇到服务端错误或网络错误时自动重试。
 func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, error) {
 	apiParams, err := params.toAPI()
 	if err != nil {
@@ -119,45 +124,84 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 		}
 		editors = append(editors, cred)
 	}
-	resp, err := c.api.CreateSandboxWithResponse(ctx, apiParams, editors...)
+	idempotencyKey := params.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey = newIdempotencyKey()
+	}
+	var resp *apis.CreateSandboxResponse
+	err = c.retryCall(func() error {
+		var e error
+		resp, e = c.api.CreateSandboxWithResponse(ctx, &apis.CreateSandboxParams{
+			IdempotencyKey: &idempotencyKey,
+		}, apiParams, editors...)
+		if e != nil {
+			return e
+		}
+		if resp.JSON201 == nil {
+			return newAPIError(resp.HTTPResponse, resp.Body)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	if resp.JSON201 == nil {
-		return nil, newAPIError(resp.HTTPResponse, resp.Body)
-	}
 	sb := newSandbox(c, resp.JSON201)
-	// Create API 可能不返回 envdAccessToken（与 Connect 同理），通过 GetSandbox 补充。
 	if !sb.envdTokenLoaded {
-		if err := sb.refreshEnvdToken(ctx); err != nil {
-			return nil, fmt.Errorf("create sandbox %s: %w", sb.sandboxID, err)
+		if tErr := sb.refreshEnvdToken(ctx); tErr != nil {
+			return nil, fmt.Errorf("create sandbox %s: %w", sb.sandboxID, tErr)
 		}
 	}
 	return sb, nil
 }
 
 // Connect 连接到一个已有的沙箱，可选择恢复已暂停的沙箱。
+// 在遇到服务端错误或网络错误时自动重试。
 func (c *Client) Connect(ctx context.Context, sandboxID string, params ConnectParams) (*Sandbox, error) {
-	resp, err := c.api.ConnectSandboxWithResponse(ctx, sandboxID, params.toAPI())
+	var resp *apis.ConnectSandboxResponse
+	err := c.retryCall(func() error {
+		var e error
+		resp, e = c.api.ConnectSandboxWithResponse(ctx, sandboxID, params.toAPI())
+		if e != nil {
+			return e
+		}
+		if resp.JSON200 == nil && resp.JSON201 == nil {
+			return newAPIError(resp.HTTPResponse, resp.Body)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	var sb *Sandbox
+	var sandboxResp *apis.Sandbox
 	if resp.JSON200 != nil {
-		sb = newSandbox(c, resp.JSON200)
-	} else if resp.JSON201 != nil {
-		sb = newSandbox(c, resp.JSON201)
+		sandboxResp = resp.JSON200
 	} else {
-		return nil, newAPIError(resp.HTTPResponse, resp.Body)
+		sandboxResp = resp.JSON201
 	}
+	sb := newSandbox(c, sandboxResp)
 	// Connect API 可能不返回 envdAccessToken，需要通过 GetSandbox 补充。
 	// envdAccessToken 用于 envd gRPC 认证，缺少时 PTY/命令执行等操作会静默失败。
 	if !sb.envdTokenLoaded {
-		if err := sb.refreshEnvdToken(ctx); err != nil {
-			return nil, fmt.Errorf("connect sandbox %s: %w", sandboxID, err)
+		if tErr := sb.refreshEnvdToken(ctx); tErr != nil {
+			return nil, fmt.Errorf("connect sandbox %s: %w", sandboxID, tErr)
 		}
 	}
 	return sb, nil
+}
+
+// retryCall 执行 API 调用并在可重试错误时自动重试。
+// 重试次数由 Config.RetryMax 控制，默认 5 次。
+func (c *Client) retryCall(fn func() error) error {
+	maxRetries := c.config.RetryMax
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if attempt >= maxRetries || !isRetryable(err) {
+			return err
+		}
+	}
 }
 
 // List 列出沙箱，支持分页和状态过滤。
@@ -583,4 +627,44 @@ func (s *Sandbox) batchUploadURL(user string) string {
 	q := url.Values{}
 	q.Set("username", user)
 	return s.envdURL() + "/files?" + q.Encode()
+}
+
+// newIdempotencyKey 生成一个 UUID v4 格式的幂等键。
+func newIdempotencyKey() string {
+	return uuid.New().String()
+}
+
+// isRetryableStatusCode 判断 HTTP 状态码是否可重试。
+// 可重试：408（超时）及 5xx 服务端错误（排除 501）。
+func isRetryableStatusCode(code int) bool {
+	if code == 408 {
+		return true
+	}
+	return code >= 500 && code != 501
+}
+
+// isRetryableError 判断错误是否为网络层面的可重试错误。
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	s := err.Error()
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "no such host") ||
+		strings.Contains(s, "unexpected EOF") ||
+		strings.Contains(s, "use of closed network connection")
+}
+
+// isRetryable 判断错误是否可重试：APIError 按状态码判断，其余按网络错误判断。
+func isRetryable(err error) bool {
+	if apiErr, ok := err.(*APIError); ok {
+		return isRetryableStatusCode(apiErr.StatusCode)
+	}
+	return isRetryableError(err)
 }

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -674,6 +674,10 @@ func isRetryableError(err error) bool {
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
 	s := err.Error()
 	return strings.Contains(s, "connection refused") ||
 		strings.Contains(s, "connection reset") ||
@@ -685,7 +689,8 @@ func isRetryableError(err error) bool {
 
 // isRetryable 判断错误是否可重试：APIError 按状态码判断，其余按网络错误判断。
 func isRetryable(err error) bool {
-	if apiErr, ok := err.(*APIError); ok {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
 		return isRetryableStatusCode(apiErr.StatusCode)
 	}
 	return isRetryableError(err)

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -130,7 +130,7 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 		idempotencyKey = newIdempotencyKey()
 	}
 	var resp *apis.CreateSandboxResponse
-	err = c.retryCall(func() error {
+	err = c.retryCall(ctx, func() error {
 		var e error
 		resp, e = c.api.CreateSandboxWithResponse(ctx, &apis.CreateSandboxParams{
 			IdempotencyKey: &idempotencyKey,
@@ -159,7 +159,7 @@ func (c *Client) Create(ctx context.Context, params CreateParams) (*Sandbox, err
 // 在遇到服务端错误或网络错误时自动重试。
 func (c *Client) Connect(ctx context.Context, sandboxID string, params ConnectParams) (*Sandbox, error) {
 	var resp *apis.ConnectSandboxResponse
-	err := c.retryCall(func() error {
+	err := c.retryCall(ctx, func() error {
 		var e error
 		resp, e = c.api.ConnectSandboxWithResponse(ctx, sandboxID, params.toAPI())
 		if e != nil {
@@ -192,7 +192,7 @@ func (c *Client) Connect(ctx context.Context, sandboxID string, params ConnectPa
 
 // retryCall 执行 API 调用并在可重试错误时自动重试。
 // 重试次数由 Config.RetryMax 控制（nil 默认 5，0 禁用重试）。
-func (c *Client) retryCall(fn func() error) error {
+func (c *Client) retryCall(ctx context.Context, fn func() error) error {
 	maxRetries := 5
 	if c.config.RetryMax != nil {
 		maxRetries = *c.config.RetryMax
@@ -202,25 +202,48 @@ func (c *Client) retryCall(fn func() error) error {
 		backoffFn = exponentialBackoff
 	}
 	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		err := fn()
 		if err == nil {
 			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		if attempt >= maxRetries || !isRetryable(err) {
 			return err
 		}
 		d := backoffFn(attempt)
 		if d > 0 {
-			time.Sleep(d)
+			timer := time.NewTimer(d)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return ctx.Err()
+			}
 		}
 	}
 }
 
 // exponentialBackoff 指数退避（500ms → 1s → 2s → 4s → 8s，上限 10s）+ 随机抖动。
 func exponentialBackoff(attempt int) time.Duration {
-	base := time.Duration(500<<attempt) * time.Millisecond
-	if base > 10*time.Second {
-		base = 10 * time.Second
+	const maxBackoff = 10 * time.Second
+	base := 500 * time.Millisecond
+	if attempt >= 5 {
+		base = maxBackoff
+	} else if attempt > 0 {
+		base *= time.Duration(1 << attempt)
+	}
+	if base > maxBackoff {
+		base = maxBackoff
 	}
 	jitter := time.Duration(rand.Int64N(int64(base/2 + 1)))
 	return base + jitter
@@ -689,6 +712,9 @@ func isRetryableError(err error) bool {
 
 // isRetryable 判断错误是否可重试：APIError 按状态码判断，其余按网络错误判断。
 func isRetryable(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
 		return isRetryableStatusCode(apiErr.StatusCode)

--- a/sandbox/types.go
+++ b/sandbox/types.go
@@ -70,6 +70,11 @@ type CreateParams struct {
 	// Resources 沙箱启动前需挂载的资源列表，可选。
 	// 平台会在沙箱启动前完成资源物化（如 GitHub 仓库克隆）。
 	Resources *[]SandboxResourceSpec
+
+	// IdempotencyKey 幂等键，可选。默认自动生成。
+	// 同一团队内重试不确定的请求时使用相同的 Key 和请求体，
+	// 可保证不会重复创建沙箱。
+	IdempotencyKey string
 }
 
 func (p CreateParams) hasKodoResource() bool {


### PR DESCRIPTION
## Summary

Add idempotent retry support for sandbox `Create` and `Connect` operations.

### Changes

- **`CreateParams.IdempotencyKey`** — optional field, auto-generates UUID v4 key
- **`retryCall` method** — shared retry loop for `Create` and `Connect`, retries on 408/5xx server errors and network errors
- **`Config.RetryMax`** — configurable retry count (default 5, 0 disables)
- **`SANDBOX_RETRY_MAX`** env var for integration tests

### Tests

- **9 unit tests**: retry on 408/500/network errors, no retry on 400/409, max retries, idempotency key generation and pass-through, Create end-to-end retry
- **2 integration tests**: same idempotency key returns same sandbox, Git clone timeout retry scenario

### Related

- Depends on: https://github.com/qiniu/api-specs/pull/24
- Fixes: qbox/sandbox#310