### PR TITLE
chore: release v7.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## 7.27.0
+
+* 新增
+  * sandbox: 为创建沙箱请求添加幂等键支持，未显式指定时自动生成 UUID
+  * sandbox: 为创建和连接沙箱增加可配置的自动重试，支持通过 RetryMax 和 RetryBackoff 控制重试次数与退避策略
+* 完善
+  * sandbox: 对 408、可重试的 5xx 和网络错误进行带抖动的指数退避重试，并在重试过程中响应 Context 取消
+* 行为变更
+  * sandbox: Create 和 Connect 默认最多重试 5 次；如需保持单次请求，可将 Config.RetryMax 设为 0
+  * sandbox: Config.RetryMax 未设置时可通过 SANDBOX_RETRY_MAX 配置重试次数
+
 ## 7.26.18
 
 * 新增

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/qiniu/go-sdk/v7
 在 `go.mod` 中：
 
 ```
-require github.com/qiniu/go-sdk/v7 v7.26.18
+require github.com/qiniu/go-sdk/v7 v7.27.0
 ```
 
 要求 **Go 1.22** 或更高版本。

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -4,7 +4,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/internal/env"
 )
 
-const Version = "7.26.18"
+const Version = "7.27.0"
 
 const (
 	CONTENT_TYPE_JSON      = "application/json"


### PR DESCRIPTION
## Summary

- Bump the SDK version to `7.27.0`.
- Update the README installation snippet to `v7.27.0`.
- Add CHANGELOG entries for Sandbox create idempotency keys and configurable retries from #232.
- Document that `Create` and `Connect` retry up to 5 times by default and that `Config.RetryMax=0` restores single-attempt behavior.

## Validation

- `git diff --check`
- `gofmt -s -l .`
- `make staticcheck`
- `make unittest`
- `go build ./examples/...`
- `go test -tags=integration -count=1 -v ./sandbox/ -run "^TestIntegrationCreateIdempotencyRetry$"`
- version consistency across `conf/conf.go`, `CHANGELOG.md`, and `README.md`